### PR TITLE
make JAXBContext a field and marshaller threadsafe

### DIFF
--- a/common-rest/src/main/java/org/uniprot/api/rest/output/converter/AbstractXmlMessageConverter.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/output/converter/AbstractXmlMessageConverter.java
@@ -3,6 +3,7 @@ package org.uniprot.api.rest.output.converter;
 import java.io.*;
 
 import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 
 import org.springframework.http.MediaType;
@@ -17,8 +18,15 @@ import com.sun.xml.bind.marshaller.DataWriter;
 public abstract class AbstractXmlMessageConverter<T, X>
         extends AbstractEntityHttpMessageConverter<T> {
 
-    public AbstractXmlMessageConverter(Class<T> messageConverterEntryClass) {
+    private JAXBContext jaxbContext;
+
+    public AbstractXmlMessageConverter(Class<T> messageConverterEntryClass, String context) {
         super(MediaType.APPLICATION_XML, messageConverterEntryClass);
+        try {
+            jaxbContext = JAXBContext.newInstance(context);
+        } catch (JAXBException e) {
+            throw new RuntimeException("JAXB initialisation failed", e);
+        }
     }
 
     protected abstract X toXml(T entity);
@@ -46,9 +54,8 @@ public abstract class AbstractXmlMessageConverter<T, X>
         outputStream.write(getFooter().getBytes());
     }
 
-    protected Marshaller createMarshaller(String context) {
+    protected Marshaller createMarshaller() {
         try {
-            JAXBContext jaxbContext = JAXBContext.newInstance(context);
             Marshaller contextMarshaller = jaxbContext.createMarshaller();
             contextMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
             contextMarshaller.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);

--- a/common-rest/src/main/java/org/uniprot/api/rest/output/converter/AbstractXmlMessageConverter.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/output/converter/AbstractXmlMessageConverter.java
@@ -18,7 +18,7 @@ import com.sun.xml.bind.marshaller.DataWriter;
 public abstract class AbstractXmlMessageConverter<T, X>
         extends AbstractEntityHttpMessageConverter<T> {
 
-    private JAXBContext jaxbContext;
+    private final JAXBContext jaxbContext;
 
     public AbstractXmlMessageConverter(Class<T> messageConverterEntryClass, String context) {
         super(MediaType.APPLICATION_XML, messageConverterEntryClass);

--- a/common-rest/src/main/java/org/uniprot/api/rest/output/converter/AbstractXmlMessageConverter.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/output/converter/AbstractXmlMessageConverter.java
@@ -61,7 +61,7 @@ public abstract class AbstractXmlMessageConverter<T, X>
             contextMarshaller.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
             return contextMarshaller;
         } catch (Exception e) {
-            throw new RuntimeException("JAXB initialisation failed", e);
+            throw new RuntimeException("JAXB marshaller creation failed", e);
         }
     }
 

--- a/common-rest/src/test/java/org/uniprot/api/rest/request/SortFieldMetaReaderImplTest.java
+++ b/common-rest/src/test/java/org/uniprot/api/rest/request/SortFieldMetaReaderImplTest.java
@@ -6,7 +6,6 @@ import static org.uniprot.api.rest.request.MetaReaderUtil.*;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/pom.xml
+++ b/pom.xml
@@ -129,21 +129,21 @@
 				<version>${commons-compress.version}</version>
 			</dependency>
 			<dependency>
-			<groupId>uk.ac.ebi.uniprot</groupId>
-			<artifactId>openapi-maven-plugin</artifactId>
-			<version>${openapi-maven-plugin.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-log4j12</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>io.dropwizard.metrics</groupId>
-			<artifactId>metrics-core</artifactId>
-			<version>${dropwizard.metrics.version}</version>
-		</dependency>
+				<groupId>uk.ac.ebi.uniprot</groupId>
+				<artifactId>openapi-maven-plugin</artifactId>
+				<version>${openapi-maven-plugin.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>org.slf4j</groupId>
+						<artifactId>slf4j-log4j12</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>io.dropwizard.metrics</groupId>
+				<artifactId>metrics-core</artifactId>
+				<version>${dropwizard.metrics.version}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/proteome-rest/src/main/java/org/uniprot/api/proteome/output/converter/GeneCentricXmlMessageConverter.java
+++ b/proteome-rest/src/main/java/org/uniprot/api/proteome/output/converter/GeneCentricXmlMessageConverter.java
@@ -14,7 +14,6 @@ import org.uniprot.core.xml.proteome.CanonicalProteinConverter;
 public class GeneCentricXmlMessageConverter
         extends AbstractXmlMessageConverter<CanonicalProtein, CanonicalGene> {
     private final CanonicalProteinConverter converter;
-    private final Marshaller marshaller;
     private static final String XML_CONTEXT = "org.uniprot.core.xml.jaxb.proteome";
     private static final String HEADER =
             "<proteomes xmlns=\"https://uniprot.org/uniprot\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"https://uniprot.org/uniprot https://www.uniprot.org/docs/proteome.xsd\">\n";
@@ -22,9 +21,8 @@ public class GeneCentricXmlMessageConverter
     private static final String FOOTER = "\n</proteomes>";
 
     public GeneCentricXmlMessageConverter() {
-        super(CanonicalProtein.class);
+        super(CanonicalProtein.class, XML_CONTEXT);
         converter = new CanonicalProteinConverter();
-        marshaller = createMarshaller(XML_CONTEXT);
     }
 
     @Override
@@ -39,7 +37,7 @@ public class GeneCentricXmlMessageConverter
 
     @Override
     protected Marshaller getMarshaller() {
-        return marshaller;
+        return createMarshaller();
     }
 
     @Override

--- a/proteome-rest/src/main/java/org/uniprot/api/proteome/output/converter/ProteomeXmlMessageConverter.java
+++ b/proteome-rest/src/main/java/org/uniprot/api/proteome/output/converter/ProteomeXmlMessageConverter.java
@@ -14,7 +14,6 @@ import org.uniprot.core.xml.proteome.ProteomeConverter;
 public class ProteomeXmlMessageConverter
         extends AbstractXmlMessageConverter<ProteomeEntry, Proteome> {
     private final ProteomeConverter converter;
-    private final Marshaller marshaller;
     private static final String XML_CONTEXT = "org.uniprot.core.xml.jaxb.proteome";
     private static final String HEADER =
             "<proteomes xmlns=\"https://uniprot.org/uniprot\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"https://uniprot.org/uniprot https://www.uniprot.org/docs/proteome.xsd\">\n";
@@ -22,9 +21,8 @@ public class ProteomeXmlMessageConverter
     private static final String FOOTER = "\n</proteomes>";
 
     public ProteomeXmlMessageConverter() {
-        super(ProteomeEntry.class);
+        super(ProteomeEntry.class, XML_CONTEXT);
         converter = new ProteomeConverter();
-        marshaller = createMarshaller(XML_CONTEXT);
     }
 
     @Override
@@ -40,7 +38,7 @@ public class ProteomeXmlMessageConverter
 
     @Override
     protected Marshaller getMarshaller() {
-        return marshaller;
+        return createMarshaller();
     }
 
     @Override

--- a/uniparc-rest/src/main/java/org/uniprot/api/uniparc/output/converter/UniParcXmlMessageConverter.java
+++ b/uniparc-rest/src/main/java/org/uniprot/api/uniparc/output/converter/UniParcXmlMessageConverter.java
@@ -13,7 +13,6 @@ import org.uniprot.core.xml.uniparc.UniParcEntryConverter;
  */
 public class UniParcXmlMessageConverter extends AbstractXmlMessageConverter<UniParcEntry, Entry> {
     private final UniParcEntryConverter converter;
-    private final Marshaller marshaller;
     private static final String XML_CONTEXT = "org.uniprot.core.xml.jaxb.uniparc";
     private static final String HEADER_PREFIX =
             "<uniparc xmlns=\"https://uniprot.org/uniprot\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"https://uniprot.org/uniprot https://www.uniprot.org/docs/uniparc.xsd\"";
@@ -23,9 +22,8 @@ public class UniParcXmlMessageConverter extends AbstractXmlMessageConverter<UniP
     private String header;
 
     public UniParcXmlMessageConverter(String version) {
-        super(UniParcEntry.class);
+        super(UniParcEntry.class, XML_CONTEXT);
         converter = new UniParcEntryConverter();
-        marshaller = createMarshaller(XML_CONTEXT);
         header = HEADER_PREFIX;
         if ((version != null) && (!version.isEmpty())) {
             header += " version=\"" + version + "\"";
@@ -46,7 +44,7 @@ public class UniParcXmlMessageConverter extends AbstractXmlMessageConverter<UniP
 
     @Override
     protected Marshaller getMarshaller() {
-        return marshaller;
+        return createMarshaller();
     }
 
     @Override

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/output/converter/UniProtKBXmlMessageConverter.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/output/converter/UniProtKBXmlMessageConverter.java
@@ -10,7 +10,6 @@ import org.uniprot.core.xml.uniprot.UniProtEntryConverter;
 public class UniProtKBXmlMessageConverter
         extends AbstractXmlMessageConverter<UniProtKBEntry, Entry> {
     private final UniProtEntryConverter converter;
-    private final Marshaller marshaller;
     private static final String XML_CONTEXT = "org.uniprot.core.xml.jaxb.uniprot";
 
     public static final String HEADER =
@@ -22,9 +21,8 @@ public class UniProtKBXmlMessageConverter
                     + "</uniprot>";
 
     public UniProtKBXmlMessageConverter() {
-        super(UniProtKBEntry.class);
+        super(UniProtKBEntry.class, XML_CONTEXT);
         converter = new UniProtEntryConverter();
-        marshaller = createMarshaller(XML_CONTEXT);
     }
 
     @Override
@@ -34,7 +32,7 @@ public class UniProtKBXmlMessageConverter
 
     @Override
     protected Marshaller getMarshaller() {
-        return marshaller;
+        return createMarshaller();
     }
 
     @Override

--- a/uniref-rest/src/main/java/org/uniprot/api/uniref/output/converter/UniRefXmlMessageConverter.java
+++ b/uniref-rest/src/main/java/org/uniprot/api/uniref/output/converter/UniRefXmlMessageConverter.java
@@ -13,7 +13,6 @@ import org.uniprot.core.xml.uniref.UniRefEntryConverter;
  */
 public class UniRefXmlMessageConverter extends AbstractXmlMessageConverter<UniRefEntry, Entry> {
     private final UniRefEntryConverter converter;
-    private final Marshaller marshaller;
     private static final String XML_CONTEXT = "org.uniprot.core.xml.jaxb.uniref";
     private static final String HEADER_PREFIX =
             "<UniRef xmlns=\"http://uniprot.org/uniref\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://uniprot.org/uniref http://www.uniprot.org/docs/uniref.xsd\"";
@@ -23,9 +22,8 @@ public class UniRefXmlMessageConverter extends AbstractXmlMessageConverter<UniRe
     private String header;
 
     public UniRefXmlMessageConverter(String version, String releaseDate) {
-        super(UniRefEntry.class);
+        super(UniRefEntry.class, XML_CONTEXT);
         converter = new UniRefEntryConverter();
-        marshaller = createMarshaller(XML_CONTEXT);
         header = HEADER_PREFIX;
         if ((version != null) && (!version.isEmpty())) {
             header += " version=\"" + version + "\"";
@@ -50,7 +48,7 @@ public class UniRefXmlMessageConverter extends AbstractXmlMessageConverter<UniRe
 
     @Override
     protected Marshaller getMarshaller() {
-        return marshaller;
+        return createMarshaller();
     }
 
     @Override


### PR DESCRIPTION
Read on the web:
JAXBContext is very expensive operation and JAXBContext is thread safe. Create marshaller/unmarshaller is very light operation and costs almost nothing comparing to JAXBContext.
