### PR TITLE
accept compressed request parameter and mutate it to accept encoding …

### DIFF
--- a/common-rest/src/main/java/org/uniprot/api/rest/controller/BasicSearchController.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/controller/BasicSearchController.java
@@ -54,6 +54,7 @@ public abstract class BasicSearchController<T> {
         MediaType contentType = getAcceptHeader(request);
         MessageConverterContext<T> context = converterContextFactory.get(resource, contentType);
         context.setFields(fields);
+        context.setFileType(getBestFileTypeFromRequest(request));
         context.setEntityOnly(true);
         if (contentType.equals(LIST_MEDIA_TYPE)) {
             context.setEntityIds(Stream.of(getEntityId(entity)));
@@ -93,6 +94,7 @@ public abstract class BasicSearchController<T> {
 
         context.setFields(fields);
         context.setFacets(result.getFacets());
+        context.setFileType(getBestFileTypeFromRequest(request));
         context.setMatchedFields(result.getMatchedFields());
         if (contentType.equals(LIST_MEDIA_TYPE)) {
             Stream<String> accList = result.getContent().map(this::getEntityId);
@@ -113,14 +115,10 @@ public abstract class BasicSearchController<T> {
     }
 
     protected DeferredResult<ResponseEntity<MessageConverterContext<T>>> download(
-            Stream<T> result,
-            String fields,
-            MediaType contentType,
-            HttpServletRequest request,
-            String encoding) {
+            Stream<T> result, String fields, MediaType contentType, HttpServletRequest request) {
         MessageConverterContext<T> context = converterContextFactory.get(resource, contentType);
         context.setFields(fields);
-        context.setFileType(FileType.bestFileTypeMatch(encoding));
+        context.setFileType(getBestFileTypeFromRequest(request));
         if (contentType.equals(LIST_MEDIA_TYPE)) {
             context.setEntityIds(result.map(this::getEntityId));
         } else {
@@ -163,6 +161,11 @@ public abstract class BasicSearchController<T> {
 
     protected MediaType getAcceptHeader(HttpServletRequest request) {
         return UniProtMediaType.valueOf(request.getHeader(HttpHeaders.ACCEPT));
+    }
+
+    protected FileType getBestFileTypeFromRequest(HttpServletRequest request) {
+        String encoding = request.getHeader(HttpHeaders.ACCEPT_ENCODING);
+        return FileType.bestFileTypeMatch(encoding);
     }
 
     private String getLocationURLForId(String redirectId) {

--- a/common-rest/src/main/java/org/uniprot/api/rest/output/context/FileType.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/output/context/FileType.java
@@ -21,6 +21,10 @@ public enum FileType {
         return extension;
     }
 
+    public String getFileType() {
+        return fileType;
+    }
+
     /**
      * @param value the requested file type
      * @return the most appropriate file type for the given input

--- a/common-rest/src/main/java/org/uniprot/api/rest/request/HttpServletRequestContentTypeMutator.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/request/HttpServletRequestContentTypeMutator.java
@@ -107,7 +107,7 @@ public class HttpServletRequestContentTypeMutator {
 
     private void mutateAcceptEncodingHeader(MutableHttpServletRequest request) {
         String compressed = request.getParameter(COMPRESSED);
-        if (Utils.notNullNotEmpty(compressed) && compressed.equalsIgnoreCase("true")) {
+        if ("true".equalsIgnoreCase(compressed)) {
             request.addHeader(HttpHeaders.ACCEPT_ENCODING, FileType.GZIP.getFileType());
         }
     }

--- a/common-rest/src/main/java/org/uniprot/api/rest/request/HttpServletRequestContentTypeMutator.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/request/HttpServletRequestContentTypeMutator.java
@@ -20,6 +20,7 @@ import org.springframework.http.MediaType;
 import org.springframework.util.MimeType;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 import org.uniprot.api.rest.output.UniProtMediaType;
+import org.uniprot.api.rest.output.context.FileType;
 import org.uniprot.core.util.Utils;
 
 /**
@@ -35,6 +36,7 @@ public class HttpServletRequestContentTypeMutator {
     public static final String ERROR_MESSAGE_ATTRIBUTE =
             "org.uniprot.api.rest.request.HttpServletRequestContentTypeMutator.errorMessageAttribute";
     static final String FORMAT = "format";
+    static final String COMPRESSED = "compressed";
     private static final Set<String> VALID_EXTENSIONS =
             UniProtMediaType.ALL_TYPES.stream()
                     .map(UniProtMediaType::getFileExtension)
@@ -60,6 +62,13 @@ public class HttpServletRequestContentTypeMutator {
     }
 
     public void mutate(
+            MutableHttpServletRequest request,
+            RequestMappingHandlerMapping requestMappingHandlerMapping) {
+        mutateAcceptHeader(request, requestMappingHandlerMapping);
+        mutateAcceptEncodingHeader(request);
+    }
+
+    private void mutateAcceptHeader(
             MutableHttpServletRequest request,
             RequestMappingHandlerMapping requestMappingHandlerMapping) {
         initResourcePath2MediaTypesMap(requestMappingHandlerMapping);
@@ -93,6 +102,13 @@ public class HttpServletRequestContentTypeMutator {
                     }
                 }
             }
+        }
+    }
+
+    private void mutateAcceptEncodingHeader(MutableHttpServletRequest request) {
+        String compressed = request.getParameter(COMPRESSED);
+        if (Utils.notNullNotEmpty(compressed) && compressed.equalsIgnoreCase("true")) {
+            request.addHeader(HttpHeaders.ACCEPT_ENCODING, FileType.GZIP.getFileType());
         }
     }
 

--- a/common-rest/src/test/java/org/uniprot/api/rest/app/FakeAppConfig.java
+++ b/common-rest/src/test/java/org/uniprot/api/rest/app/FakeAppConfig.java
@@ -1,0 +1,48 @@
+package org.uniprot.api.rest.app;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.uniprot.api.rest.output.UniProtMediaType;
+import org.uniprot.api.rest.output.context.MessageConverterContext;
+import org.uniprot.api.rest.output.context.MessageConverterContextFactory;
+import org.uniprot.api.rest.output.converter.*;
+
+/**
+ * @author lgonzales
+ * @since 29/07/2020
+ */
+@Configuration
+public class FakeAppConfig {
+
+    @Bean
+    @Profile("use-fake-app")
+    public MessageConverterContextFactory<String> messageConverterContextFactory() {
+        MessageConverterContextFactory<String> contextFactory =
+                new MessageConverterContextFactory<>();
+
+        MessageConverterContext<String> converter =
+                MessageConverterContext.<String>builder()
+                        .resource(MessageConverterContextFactory.Resource.TAXONOMY)
+                        .contentType(UniProtMediaType.LIST_MEDIA_TYPE)
+                        .build();
+        contextFactory.addMessageConverterContext(converter);
+        return contextFactory;
+    }
+
+    @Bean
+    @Profile("use-fake-app")
+    public WebMvcConfigurer extendedMessageConverters() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
+                converters.add(new ErrorMessageConverter());
+                converters.add(new ListMessageConverter());
+            }
+        };
+    }
+}

--- a/common-rest/src/test/java/org/uniprot/api/rest/app/FakeBasicSearchController.java
+++ b/common-rest/src/test/java/org/uniprot/api/rest/app/FakeBasicSearchController.java
@@ -1,0 +1,53 @@
+package org.uniprot.api.rest.app;
+
+import static org.uniprot.api.rest.output.UniProtMediaType.*;
+
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.uniprot.api.rest.controller.BasicSearchController;
+import org.uniprot.api.rest.output.context.MessageConverterContext;
+import org.uniprot.api.rest.output.context.MessageConverterContextFactory;
+
+/**
+ * @author lgonzales
+ * @since 29/07/2020
+ */
+@Profile("use-fake-app")
+@RestController
+@RequestMapping("/fakeBasicSearch")
+public class FakeBasicSearchController extends BasicSearchController<String> {
+
+    protected FakeBasicSearchController(
+            ApplicationEventPublisher eventPublisher,
+            MessageConverterContextFactory<String> converterContextFactory) {
+        super(
+                eventPublisher,
+                converterContextFactory,
+                null,
+                MessageConverterContextFactory.Resource.TAXONOMY);
+    }
+
+    @GetMapping(value = "/fakeId", produces = LIST_MEDIA_TYPE_VALUE)
+    public ResponseEntity<MessageConverterContext<String>> getByAccession(
+            HttpServletRequest request) {
+        return super.getEntityResponse("Response value", "", request);
+    }
+
+    @Override
+    protected String getEntityId(String entity) {
+        return entity;
+    }
+
+    @Override
+    protected Optional<String> getEntityRedirectId(String entity) {
+        return Optional.empty();
+    }
+}

--- a/common-rest/src/test/java/org/uniprot/api/rest/app/FakeRESTApp.java
+++ b/common-rest/src/test/java/org/uniprot/api/rest/app/FakeRESTApp.java
@@ -16,7 +16,12 @@ import org.uniprot.api.rest.output.header.HttpCommonHeaderConfig;
  */
 @Profile("use-fake-app")
 @SpringBootApplication
-@Import({FakeController.class, HttpCommonHeaderConfig.class})
+@Import({
+    FakeController.class,
+    HttpCommonHeaderConfig.class,
+    FakeAppConfig.class,
+    FakeBasicSearchController.class
+})
 @ComponentScan(basePackages = "org.uniprot.api.rest.validation.error")
 public class FakeRESTApp {
     public static void main(String[] args) {

--- a/common-rest/src/test/java/org/uniprot/api/rest/output/context/FileTypeTest.java
+++ b/common-rest/src/test/java/org/uniprot/api/rest/output/context/FileTypeTest.java
@@ -1,8 +1,8 @@
 package org.uniprot.api.rest.output.context;
 
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * @author lgonzales

--- a/common-rest/src/test/java/org/uniprot/api/rest/output/context/FileTypeTest.java
+++ b/common-rest/src/test/java/org/uniprot/api/rest/output/context/FileTypeTest.java
@@ -1,0 +1,37 @@
+package org.uniprot.api.rest.output.context;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author lgonzales
+ * @since 28/07/2020
+ */
+class FileTypeTest {
+
+    @Test
+    void getExtension() {
+        assertEquals(".gz", FileType.GZIP.getExtension());
+    }
+
+    @Test
+    void getFileType() {
+        assertEquals("file", FileType.FILE.getFileType());
+    }
+
+    @Test
+    void bestFileTypeMatchGzip() {
+        assertEquals(FileType.GZIP, FileType.bestFileTypeMatch("gzip"));
+    }
+
+    @Test
+    void bestFileTypeMatchFile() {
+        assertEquals(FileType.FILE, FileType.bestFileTypeMatch("file"));
+    }
+
+    @Test
+    void bestFileTypeMatchInvalidDefaultToFile() {
+        assertEquals(FileType.FILE, FileType.bestFileTypeMatch("invalid"));
+    }
+}

--- a/proteome-rest/src/main/java/org/uniprot/api/proteome/controller/GeneCentricController.java
+++ b/proteome-rest/src/main/java/org/uniprot/api/proteome/controller/GeneCentricController.java
@@ -20,13 +20,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.async.DeferredResult;
 import org.uniprot.api.common.repository.search.QueryResult;
 import org.uniprot.api.proteome.request.GeneCentricRequest;
@@ -101,9 +95,8 @@ public class GeneCentricController extends BasicSearchController<CanonicalProtei
                             @Content(mediaType = LIST_MEDIA_TYPE_VALUE)
                         })
             })
-    @RequestMapping(
+    @GetMapping(
             value = "/search",
-            method = RequestMethod.GET,
             produces = {APPLICATION_JSON_VALUE, APPLICATION_XML_VALUE, LIST_MEDIA_TYPE_VALUE})
     public ResponseEntity<MessageConverterContext<CanonicalProtein>> searchCursor(
             @Valid @ModelAttribute GeneCentricRequest searchRequest,
@@ -114,9 +107,8 @@ public class GeneCentricController extends BasicSearchController<CanonicalProtei
     }
 
     @Tag(name = "genecentric")
-    @RequestMapping(
+    @GetMapping(
             value = "/upid/{upid}",
-            method = RequestMethod.GET,
             produces = {APPLICATION_JSON_VALUE, APPLICATION_XML_VALUE, LIST_MEDIA_TYPE_VALUE})
     @Operation(
             summary = "Fetch all proteins of Proteome id.",
@@ -198,17 +190,13 @@ public class GeneCentricController extends BasicSearchController<CanonicalProtei
                             @Content(mediaType = LIST_MEDIA_TYPE_VALUE)
                         })
             })
-    @RequestMapping(
+    @GetMapping(
             value = "/download",
-            method = RequestMethod.GET,
             produces = {LIST_MEDIA_TYPE_VALUE, APPLICATION_JSON_VALUE, XLS_MEDIA_TYPE_VALUE})
     public DeferredResult<ResponseEntity<MessageConverterContext<CanonicalProtein>>> download(
-            @Valid @ModelAttribute GeneCentricRequest searchRequest,
-            @RequestHeader(value = "Accept-Encoding", required = false) String encoding,
-            HttpServletRequest request) {
+            @Valid @ModelAttribute GeneCentricRequest searchRequest, HttpServletRequest request) {
         Stream<CanonicalProtein> result = service.download(searchRequest);
-        return super.download(
-                result, searchRequest.getFields(), getAcceptHeader(request), request, encoding);
+        return super.download(result, searchRequest.getFields(), getAcceptHeader(request), request);
     }
 
     @Tag(name = "genecentric")
@@ -226,9 +214,8 @@ public class GeneCentricController extends BasicSearchController<CanonicalProtei
                             @Content(mediaType = LIST_MEDIA_TYPE_VALUE)
                         })
             })
-    @RequestMapping(
+    @GetMapping(
             value = "/{accession}",
-            method = RequestMethod.GET,
             produces = {APPLICATION_JSON_VALUE, APPLICATION_XML_VALUE, LIST_MEDIA_TYPE_VALUE})
     public ResponseEntity<MessageConverterContext<CanonicalProtein>> getByAccession(
             @Parameter(description = "UnirotKB accession")

--- a/proteome-rest/src/main/java/org/uniprot/api/proteome/controller/ProteomeController.java
+++ b/proteome-rest/src/main/java/org/uniprot/api/proteome/controller/ProteomeController.java
@@ -22,13 +22,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.async.DeferredResult;
 import org.uniprot.api.common.repository.search.QueryResult;
 import org.uniprot.api.proteome.request.ProteomeRequest;
@@ -80,9 +74,8 @@ public class ProteomeController extends BasicSearchController<ProteomeEntry> {
                     "The Proteomes service provides access to UniProtKB proteomes with"
                             + " end points to search for proteomes (including reference or redundant proteomes) by UniProt"
                             + " proteome identifiers, species names or taxonomy identifiers")
-    @RequestMapping(
+    @GetMapping(
             value = "/search",
-            method = RequestMethod.GET,
             produces = {
                 TSV_MEDIA_TYPE_VALUE,
                 LIST_MEDIA_TYPE_VALUE,
@@ -128,9 +121,8 @@ public class ProteomeController extends BasicSearchController<ProteomeEntry> {
     }
 
     @Tag(name = "proteome")
-    @RequestMapping(
+    @GetMapping(
             value = "/{upid}",
-            method = RequestMethod.GET,
             produces = {
                 TSV_MEDIA_TYPE_VALUE,
                 LIST_MEDIA_TYPE_VALUE,
@@ -177,9 +169,8 @@ public class ProteomeController extends BasicSearchController<ProteomeEntry> {
     }
 
     @Tag(name = "proteome")
-    @RequestMapping(
+    @GetMapping(
             value = "/download",
-            method = RequestMethod.GET,
             produces = {
                 TSV_MEDIA_TYPE_VALUE,
                 LIST_MEDIA_TYPE_VALUE,
@@ -217,10 +208,9 @@ public class ProteomeController extends BasicSearchController<ProteomeEntry> {
             @Valid @ModelAttribute ProteomeRequest searchRequest,
             @RequestHeader(value = "Accept", defaultValue = APPLICATION_JSON_VALUE)
                     MediaType contentType,
-            @RequestHeader(value = "Accept-Encoding", required = false) String encoding,
             HttpServletRequest request) {
         Stream<ProteomeEntry> result = queryService.download(searchRequest);
-        return super.download(result, searchRequest.getFields(), contentType, request, encoding);
+        return super.download(result, searchRequest.getFields(), contentType, request);
     }
 
     @Override

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/disease/DiseaseController.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/disease/DiseaseController.java
@@ -167,12 +167,11 @@ public class DiseaseController extends BasicSearchController<DiseaseEntry> {
             @Valid @ModelAttribute DiseaseSearchRequest searchRequest,
             @RequestHeader(value = "Accept", defaultValue = APPLICATION_JSON_VALUE)
                     MediaType contentType,
-            @RequestHeader(value = "Accept-Encoding", required = false) String encoding,
             HttpServletRequest request) {
 
         Stream<DiseaseEntry> result = this.diseaseService.download(searchRequest);
 
-        return super.download(result, searchRequest.getFields(), contentType, request, encoding);
+        return super.download(result, searchRequest.getFields(), contentType, request);
     }
 
     @Override

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/keyword/KeywordController.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/keyword/KeywordController.java
@@ -159,12 +159,9 @@ public class KeywordController extends BasicSearchController<KeywordEntry> {
                         })
             })
     public DeferredResult<ResponseEntity<MessageConverterContext<KeywordEntry>>> download(
-            @Valid @ModelAttribute KeywordRequest searchRequest,
-            @RequestHeader(value = "Accept-Encoding", required = false) String encoding,
-            HttpServletRequest request) {
+            @Valid @ModelAttribute KeywordRequest searchRequest, HttpServletRequest request) {
         Stream<KeywordEntry> result = keywordService.download(searchRequest);
-        return super.download(
-                result, searchRequest.getFields(), getAcceptHeader(request), request, encoding);
+        return super.download(result, searchRequest.getFields(), getAcceptHeader(request), request);
     }
 
     @Override

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/literature/LiteratureController.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/literature/LiteratureController.java
@@ -174,10 +174,9 @@ public class LiteratureController extends BasicSearchController<LiteratureEntry>
             @Valid @ModelAttribute LiteratureRequest searchRequest,
             @RequestHeader(value = "Accept", defaultValue = APPLICATION_JSON_VALUE)
                     MediaType contentType,
-            @RequestHeader(value = "Accept-Encoding", required = false) String encoding,
             HttpServletRequest request) {
         Stream<LiteratureEntry> result = literatureService.download(searchRequest);
-        return super.download(result, searchRequest.getFields(), contentType, request, encoding);
+        return super.download(result, searchRequest.getFields(), contentType, request);
     }
 
     @Override

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/subcell/SubcellularLocationController.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/subcell/SubcellularLocationController.java
@@ -185,11 +185,10 @@ public class SubcellularLocationController extends BasicSearchController<Subcell
                     @Valid @ModelAttribute SubcellularLocationRequest searchRequest,
                     @RequestHeader(value = "Accept", defaultValue = APPLICATION_JSON_VALUE)
                             MediaType contentType,
-                    @RequestHeader(value = "Accept-Encoding", required = false) String encoding,
                     HttpServletRequest request) {
         Stream<SubcellularLocationEntry> result =
                 subcellularLocationService.download(searchRequest);
-        return super.download(result, searchRequest.getFields(), contentType, request, encoding);
+        return super.download(result, searchRequest.getFields(), contentType, request);
     }
 
     @Override

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/taxonomy/TaxonomyController.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/taxonomy/TaxonomyController.java
@@ -168,10 +168,9 @@ public class TaxonomyController extends BasicSearchController<TaxonomyEntry> {
             @Valid @ModelAttribute TaxonomyRequest searchRequest,
             @RequestHeader(value = "Accept", defaultValue = APPLICATION_JSON_VALUE)
                     MediaType contentType,
-            @RequestHeader(value = "Accept-Encoding", required = false) String encoding,
             HttpServletRequest request) {
         Stream<TaxonomyEntry> result = taxonomyService.download(searchRequest);
-        return super.download(result, searchRequest.getFields(), contentType, request, encoding);
+        return super.download(result, searchRequest.getFields(), contentType, request);
     }
 
     @Override


### PR DESCRIPTION
Before this code change, we would only identify the compressed(gzip) option through "Accept-Encoding" request header.
But front end is unable to send us request headers for the download use case.
so, now we also have to accept request parameter compressed=true. 
The way the we implemented it to make it flexible is during the request filter we identify it and add  "Accept-Encoding" to request header when we have a request parameter compressed=true....