### PR TITLE
White list fields

### DIFF
--- a/common-rest/src/main/java/org/uniprot/api/rest/service/query/UniProtQueryProcessor.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/service/query/UniProtQueryProcessor.java
@@ -1,6 +1,7 @@
 package org.uniprot.api.rest.service.query;
 
 import java.util.List;
+import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -34,8 +35,9 @@ public class UniProtQueryProcessor implements QueryProcessor {
     private static final EscapeQuerySyntaxImpl ESCAPER = new EscapeQuerySyntaxImpl();
     private final UniProtQueryNodeProcessorPipeline queryProcessorPipeline;
 
-    public UniProtQueryProcessor(List<SearchFieldItem> optimisableFields) {
-        this(new UniProtQueryNodeProcessorPipeline(optimisableFields));
+    public UniProtQueryProcessor(
+            List<SearchFieldItem> optimisableFields, Map<String, String> whiteListFields) {
+        this(new UniProtQueryNodeProcessorPipeline(optimisableFields, whiteListFields));
     }
 
     public UniProtQueryProcessor(UniProtQueryNodeProcessorPipeline pipeline) {

--- a/common-rest/src/main/java/org/uniprot/api/rest/service/query/processor/UniProtQueryNodeProcessorPipeline.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/service/query/processor/UniProtQueryNodeProcessorPipeline.java
@@ -1,6 +1,7 @@
 package org.uniprot.api.rest.service.query.processor;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
 import org.apache.lucene.queryparser.flexible.core.parser.EscapeQuerySyntax;
@@ -22,10 +23,11 @@ import org.uniprot.store.config.searchfield.model.SearchFieldItem;
  * @author Edd
  */
 public class UniProtQueryNodeProcessorPipeline extends QueryNodeProcessorPipeline {
-    public UniProtQueryNodeProcessorPipeline(List<SearchFieldItem> optimisableFields) {
+    public UniProtQueryNodeProcessorPipeline(
+            List<SearchFieldItem> optimisableFields, Map<String, String> whiteListFields) {
         super(new StandardQueryConfigHandler());
 
-        add(new UniProtFieldQueryNodeProcessor(optimisableFields));
+        add(new UniProtFieldQueryNodeProcessor(optimisableFields, whiteListFields));
         add(new UniProtOpenRangeQueryNodeProcessor());
         add(new UniProtPointRangeQueryNodeProcessor());
         add(new UniProtTermRangeQueryNodeProcessor());

--- a/common-rest/src/main/java/org/uniprot/api/rest/validation/config/WhitelistFieldConfig.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/validation/config/WhitelistFieldConfig.java
@@ -1,0 +1,33 @@
+package org.uniprot.api.rest.validation.config;
+
+import java.util.Map;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+
+/**
+ * In Our UniProtKB database we have some ids that has the following format
+ * <prefix><colon><postfix>, for example (HGNC:3689). These Ids, are processed wrongly by solr query
+ * parser, basically, it identify HGNC as a field name, causing an error in the request, because we
+ * do not have a defined field named HGNC in our solr schema.
+ *
+ * <p>In order to sort out this problem, we created this property file with a list of trouble ids
+ * that will need to be whitelisted in our field validation and handled specially in our
+ * UniProtFieldQueryNodeProcessor.
+ *
+ * @author lgonzales
+ * @since 24/09/2020
+ */
+@Component
+@Getter
+@Setter
+@PropertySource({"classpath:valid-field-whitelist.properties"})
+@ConfigurationProperties(prefix = "whitelist")
+public class WhitelistFieldConfig {
+
+    private Map<String, Map<String, String>> field;
+}

--- a/common-rest/src/main/resources/valid-field-whitelist.properties
+++ b/common-rest/src/main/resources/valid-field-whitelist.properties
@@ -1,0 +1,17 @@
+#################################### DOCUMENTATION / HELP ###########################################################
+# In Our UniProtKB database we have some ids that has the following format <prefix><colon><postfix>,
+# for example (HGNC:3689).
+# These Ids, are processed wrongly by solr query parser, basically, it identify HGNC as a field name, causing
+# an error in the request, because we do not have a defined field named HGNC in our solr schema.
+#
+# In order to sort out this problem, we created this property file with a list of trouble ids that will need to be
+# whitelisted in our field validation and handled specially in our UniProtFieldQueryNodeProcessor.
+#
+# Config Structure example explanation:
+#          whitelist.field =  prefix
+#          uniprotkb =  solr data type
+#          hgnc = id Prefix
+#          The value is the regex that we should use to fine grain this id and try avoid false positives.
+###################################################################################################################
+whitelist.field.uniprotkb.hgnc=^[0-9]+$
+whitelist.field.uniprotkb.pr=(?i)([OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z]([0-9][A-Z][A-Z0-9]{2}){1,2}[0-9])(-[0-9]+)?

--- a/common-rest/src/test/java/org/uniprot/api/rest/service/BasicSearchServiceTest.java
+++ b/common-rest/src/test/java/org/uniprot/api/rest/service/BasicSearchServiceTest.java
@@ -1,6 +1,7 @@
 package org.uniprot.api.rest.service;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -13,7 +14,7 @@ import org.uniprot.api.common.repository.search.SolrRequest;
 import org.uniprot.api.rest.request.SearchRequest;
 import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
 
-public class BasicSearchServiceTest {
+class BasicSearchServiceTest {
     private static BasicSearchService mockService;
     private SearchRequest request;
 
@@ -21,7 +22,7 @@ public class BasicSearchServiceTest {
     static void setUpBeforeAll() {
         mockService = Mockito.mock(BasicSearchService.class, Mockito.CALLS_REAL_METHODS);
         Mockito.when(mockService.getQueryProcessor())
-                .thenReturn(new UniProtQueryProcessor(emptyList()));
+                .thenReturn(new UniProtQueryProcessor(emptyList(), emptyMap()));
         ReflectionTestUtils.setField(
                 mockService,
                 "solrBatchSize",

--- a/proteome-rest/src/main/java/org/uniprot/api/proteome/controller/GeneCentricController.java
+++ b/proteome-rest/src/main/java/org/uniprot/api/proteome/controller/GeneCentricController.java
@@ -34,7 +34,6 @@ import org.uniprot.core.proteome.CanonicalProtein;
 import org.uniprot.core.xml.jaxb.proteome.CanonicalGene;
 import org.uniprot.store.config.UniProtDataType;
 import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
-import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
 import org.uniprot.store.search.field.validator.FieldRegexConstants;
 
 import uk.ac.ebi.uniprot.openapi.extension.ModelFieldMeta;
@@ -56,6 +55,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public class GeneCentricController extends BasicSearchController<CanonicalProtein> {
 
     private final GeneCentricService service;
+    private final SearchFieldConfig geneCentricSearchFieldConfig;
 
     @Autowired
     public GeneCentricController(
@@ -63,9 +63,11 @@ public class GeneCentricController extends BasicSearchController<CanonicalProtei
             GeneCentricService service,
             @Qualifier("GENECENTRIC")
                     MessageConverterContextFactory<CanonicalProtein> converterContextFactory,
-            ThreadPoolTaskExecutor downloadTaskExecutor) {
+            ThreadPoolTaskExecutor downloadTaskExecutor,
+            SearchFieldConfig geneCentricSearchFieldConfig) {
         super(eventPublisher, converterContextFactory, downloadTaskExecutor, GENECENTRIC);
         this.service = service;
+        this.geneCentricSearchFieldConfig = geneCentricSearchFieldConfig;
     }
 
     @Tag(name = "genecentric", description = "gene centric service")
@@ -153,10 +155,10 @@ public class GeneCentricController extends BasicSearchController<CanonicalProtei
             HttpServletRequest request,
             HttpServletResponse response) {
         GeneCentricRequest searchRequest = new GeneCentricRequest();
-        SearchFieldConfig searchFieldConfig =
-                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.GENECENTRIC);
         String query =
-                searchFieldConfig.getSearchFieldItemByName("upid").getFieldName() + ":" + upid;
+                geneCentricSearchFieldConfig.getSearchFieldItemByName("upid").getFieldName()
+                        + ":"
+                        + upid;
         searchRequest.setQuery(query);
         searchRequest.setFields(fields);
         QueryResult<CanonicalProtein> results = service.search(searchRequest);

--- a/proteome-rest/src/main/java/org/uniprot/api/proteome/service/GeneCentricService.java
+++ b/proteome-rest/src/main/java/org/uniprot/api/proteome/service/GeneCentricService.java
@@ -1,8 +1,5 @@
 package org.uniprot.api.proteome.service;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Service;
@@ -11,7 +8,6 @@ import org.uniprot.api.proteome.repository.GeneCentricFacetConfig;
 import org.uniprot.api.proteome.repository.GeneCentricQueryRepository;
 import org.uniprot.api.rest.service.BasicSearchService;
 import org.uniprot.api.rest.service.query.QueryProcessor;
-import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
 import org.uniprot.core.proteome.CanonicalProtein;
 import org.uniprot.store.config.UniProtDataType;
 import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
@@ -26,7 +22,7 @@ import org.uniprot.store.search.document.proteome.GeneCentricDocument;
 @Service
 @Import(GeneCentricSolrQueryConfig.class)
 public class GeneCentricService extends BasicSearchService<GeneCentricDocument, CanonicalProtein> {
-    private static final String GENECENTRIC_ID_FIELD = "accession_id";
+    public static final String GENECENTRIC_ID_FIELD = "accession_id";
     private final SearchFieldConfig searchFieldConfig;
     private final QueryProcessor queryProcessor;
 
@@ -35,7 +31,8 @@ public class GeneCentricService extends BasicSearchService<GeneCentricDocument, 
             GeneCentricQueryRepository repository,
             GeneCentricFacetConfig facetConfig,
             GeneCentricSortClause solrSortClause,
-            SolrQueryConfig geneCentricSolrQueryConf) {
+            SolrQueryConfig geneCentricSolrQueryConf,
+            QueryProcessor geneCentricQueryProcessor) {
         super(
                 repository,
                 new GeneCentricEntryConverter(),
@@ -44,7 +41,7 @@ public class GeneCentricService extends BasicSearchService<GeneCentricDocument, 
                 facetConfig);
         searchFieldConfig =
                 SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.GENECENTRIC);
-        this.queryProcessor = new UniProtQueryProcessor(getDefaultSearchOptimisedFieldItems());
+        this.queryProcessor = geneCentricQueryProcessor;
     }
 
     @Override
@@ -55,9 +52,5 @@ public class GeneCentricService extends BasicSearchService<GeneCentricDocument, 
     @Override
     protected QueryProcessor getQueryProcessor() {
         return queryProcessor;
-    }
-
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        return Collections.singletonList(getIdField());
     }
 }

--- a/proteome-rest/src/main/java/org/uniprot/api/proteome/service/GeneCentricService.java
+++ b/proteome-rest/src/main/java/org/uniprot/api/proteome/service/GeneCentricService.java
@@ -9,9 +9,7 @@ import org.uniprot.api.proteome.repository.GeneCentricQueryRepository;
 import org.uniprot.api.rest.service.BasicSearchService;
 import org.uniprot.api.rest.service.query.QueryProcessor;
 import org.uniprot.core.proteome.CanonicalProtein;
-import org.uniprot.store.config.UniProtDataType;
 import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
-import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
 import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 import org.uniprot.store.search.document.proteome.GeneCentricDocument;
 
@@ -32,15 +30,15 @@ public class GeneCentricService extends BasicSearchService<GeneCentricDocument, 
             GeneCentricFacetConfig facetConfig,
             GeneCentricSortClause solrSortClause,
             SolrQueryConfig geneCentricSolrQueryConf,
-            QueryProcessor geneCentricQueryProcessor) {
+            QueryProcessor geneCentricQueryProcessor,
+            SearchFieldConfig geneCentricSearchFieldConfig) {
         super(
                 repository,
                 new GeneCentricEntryConverter(),
                 solrSortClause,
                 geneCentricSolrQueryConf,
                 facetConfig);
-        searchFieldConfig =
-                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.GENECENTRIC);
+        searchFieldConfig = geneCentricSearchFieldConfig;
         this.queryProcessor = geneCentricQueryProcessor;
     }
 

--- a/proteome-rest/src/main/java/org/uniprot/api/proteome/service/GeneCentricSolrQueryConfig.java
+++ b/proteome-rest/src/main/java/org/uniprot/api/proteome/service/GeneCentricSolrQueryConfig.java
@@ -1,9 +1,21 @@
 package org.uniprot.api.proteome.service;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.uniprot.api.common.repository.search.SolrQueryConfig;
 import org.uniprot.api.common.repository.search.SolrQueryConfigFileReader;
+import org.uniprot.api.rest.service.query.QueryProcessor;
+import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
+import org.uniprot.api.rest.validation.config.WhitelistFieldConfig;
+import org.uniprot.store.config.UniProtDataType;
+import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
+import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
+import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 
 @Configuration
 public class GeneCentricSolrQueryConfig {
@@ -12,5 +24,25 @@ public class GeneCentricSolrQueryConfig {
     @Bean
     public SolrQueryConfig geneCentricSolrQueryConf() {
         return new SolrQueryConfigFileReader(RESOURCE_LOCATION).getConfig();
+    }
+
+    @Bean
+    public QueryProcessor geneCentricQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+        Map<String, String> geneCentricWhitelistFields =
+                whiteListFieldConfig
+                        .getField()
+                        .getOrDefault(
+                                UniProtDataType.GENECENTRIC.toString().toLowerCase(),
+                                new HashMap<>());
+        return new UniProtQueryProcessor(
+                getDefaultSearchOptimisedFieldItems(), geneCentricWhitelistFields);
+    }
+
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
+        SearchFieldConfig searchFieldConfig =
+                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.GENECENTRIC);
+        return Collections.singletonList(
+                searchFieldConfig.getSearchFieldItemByName(
+                        GeneCentricService.GENECENTRIC_ID_FIELD));
     }
 }

--- a/proteome-rest/src/main/java/org/uniprot/api/proteome/service/GeneCentricSolrQueryConfig.java
+++ b/proteome-rest/src/main/java/org/uniprot/api/proteome/service/GeneCentricSolrQueryConfig.java
@@ -27,7 +27,14 @@ public class GeneCentricSolrQueryConfig {
     }
 
     @Bean
-    public QueryProcessor geneCentricQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+    public SearchFieldConfig geneCentricSearchFieldConfig() {
+        return SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.GENECENTRIC);
+    }
+
+    @Bean
+    public QueryProcessor geneCentricQueryProcessor(
+            WhitelistFieldConfig whiteListFieldConfig,
+            SearchFieldConfig geneCentricSearchFieldConfig) {
         Map<String, String> geneCentricWhitelistFields =
                 whiteListFieldConfig
                         .getField()
@@ -35,14 +42,14 @@ public class GeneCentricSolrQueryConfig {
                                 UniProtDataType.GENECENTRIC.toString().toLowerCase(),
                                 new HashMap<>());
         return new UniProtQueryProcessor(
-                getDefaultSearchOptimisedFieldItems(), geneCentricWhitelistFields);
+                getDefaultSearchOptimisedFieldItems(geneCentricSearchFieldConfig),
+                geneCentricWhitelistFields);
     }
 
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        SearchFieldConfig searchFieldConfig =
-                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.GENECENTRIC);
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems(
+            SearchFieldConfig geneCentricSearchFieldConfig) {
         return Collections.singletonList(
-                searchFieldConfig.getSearchFieldItemByName(
+                geneCentricSearchFieldConfig.getSearchFieldItemByName(
                         GeneCentricService.GENECENTRIC_ID_FIELD));
     }
 }

--- a/proteome-rest/src/main/java/org/uniprot/api/proteome/service/ProteomeQueryService.java
+++ b/proteome-rest/src/main/java/org/uniprot/api/proteome/service/ProteomeQueryService.java
@@ -8,9 +8,7 @@ import org.uniprot.api.proteome.repository.ProteomeQueryRepository;
 import org.uniprot.api.rest.service.BasicSearchService;
 import org.uniprot.api.rest.service.query.QueryProcessor;
 import org.uniprot.core.proteome.ProteomeEntry;
-import org.uniprot.store.config.UniProtDataType;
 import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
-import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
 import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 import org.uniprot.store.search.document.proteome.ProteomeDocument;
 
@@ -30,14 +28,15 @@ public class ProteomeQueryService extends BasicSearchService<ProteomeDocument, P
             ProteomeFacetConfig facetConfig,
             ProteomeSortClause solrSortClause,
             SolrQueryConfig proteomeSolrQueryConf,
-            QueryProcessor proteomeQueryProcessor) {
+            QueryProcessor proteomeQueryProcessor,
+            SearchFieldConfig proteomeSearchFieldConfig) {
         super(
                 repository,
                 new ProteomeEntryConverter(),
                 solrSortClause,
                 proteomeSolrQueryConf,
                 facetConfig);
-        fieldConfig = SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.PROTEOME);
+        fieldConfig = proteomeSearchFieldConfig;
         this.queryProcessor = proteomeQueryProcessor;
     }
 

--- a/proteome-rest/src/main/java/org/uniprot/api/proteome/service/ProteomeQueryService.java
+++ b/proteome-rest/src/main/java/org/uniprot/api/proteome/service/ProteomeQueryService.java
@@ -1,8 +1,5 @@
 package org.uniprot.api.proteome.service;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Service;
 import org.uniprot.api.common.repository.search.SolrQueryConfig;
@@ -10,7 +7,6 @@ import org.uniprot.api.proteome.repository.ProteomeFacetConfig;
 import org.uniprot.api.proteome.repository.ProteomeQueryRepository;
 import org.uniprot.api.rest.service.BasicSearchService;
 import org.uniprot.api.rest.service.query.QueryProcessor;
-import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
 import org.uniprot.core.proteome.ProteomeEntry;
 import org.uniprot.store.config.UniProtDataType;
 import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
@@ -25,7 +21,7 @@ import org.uniprot.store.search.document.proteome.ProteomeDocument;
 @Service
 @Import(ProteomeSolrQueryConfig.class)
 public class ProteomeQueryService extends BasicSearchService<ProteomeDocument, ProteomeEntry> {
-    private static final String PROTEOME_ID_FIELD = "upid";
+    public static final String PROTEOME_ID_FIELD = "upid";
     private final SearchFieldConfig fieldConfig;
     private final QueryProcessor queryProcessor;
 
@@ -33,7 +29,8 @@ public class ProteomeQueryService extends BasicSearchService<ProteomeDocument, P
             ProteomeQueryRepository repository,
             ProteomeFacetConfig facetConfig,
             ProteomeSortClause solrSortClause,
-            SolrQueryConfig proteomeSolrQueryConf) {
+            SolrQueryConfig proteomeSolrQueryConf,
+            QueryProcessor proteomeQueryProcessor) {
         super(
                 repository,
                 new ProteomeEntryConverter(),
@@ -41,7 +38,7 @@ public class ProteomeQueryService extends BasicSearchService<ProteomeDocument, P
                 proteomeSolrQueryConf,
                 facetConfig);
         fieldConfig = SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.PROTEOME);
-        this.queryProcessor = new UniProtQueryProcessor(getDefaultSearchOptimisedFieldItems());
+        this.queryProcessor = proteomeQueryProcessor;
     }
 
     @Override
@@ -52,9 +49,5 @@ public class ProteomeQueryService extends BasicSearchService<ProteomeDocument, P
     @Override
     protected QueryProcessor getQueryProcessor() {
         return queryProcessor;
-    }
-
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        return Collections.singletonList(getIdField());
     }
 }

--- a/proteome-rest/src/main/java/org/uniprot/api/proteome/service/ProteomeSolrQueryConfig.java
+++ b/proteome-rest/src/main/java/org/uniprot/api/proteome/service/ProteomeSolrQueryConfig.java
@@ -27,20 +27,28 @@ public class ProteomeSolrQueryConfig {
     }
 
     @Bean
-    public QueryProcessor proteomeQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+    public SearchFieldConfig proteomeSearchFieldConfig() {
+        return SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.PROTEOME);
+    }
+
+    @Bean
+    public QueryProcessor proteomeQueryProcessor(
+            WhitelistFieldConfig whiteListFieldConfig,
+            SearchFieldConfig proteomeSearchFieldConfig) {
         Map<String, String> proteomeWhiteListFields =
                 whiteListFieldConfig
                         .getField()
                         .getOrDefault(
                                 UniProtDataType.PROTEOME.toString().toLowerCase(), new HashMap<>());
         return new UniProtQueryProcessor(
-                getDefaultSearchOptimisedFieldItems(), proteomeWhiteListFields);
+                getDefaultSearchOptimisedFieldItems(proteomeSearchFieldConfig),
+                proteomeWhiteListFields);
     }
 
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        SearchFieldConfig searchFieldConfig =
-                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.PROTEOME);
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems(
+            SearchFieldConfig proteomeSearchFieldConfig) {
         return Collections.singletonList(
-                searchFieldConfig.getSearchFieldItemByName(ProteomeQueryService.PROTEOME_ID_FIELD));
+                proteomeSearchFieldConfig.getSearchFieldItemByName(
+                        ProteomeQueryService.PROTEOME_ID_FIELD));
     }
 }

--- a/proteome-rest/src/main/java/org/uniprot/api/proteome/service/ProteomeSolrQueryConfig.java
+++ b/proteome-rest/src/main/java/org/uniprot/api/proteome/service/ProteomeSolrQueryConfig.java
@@ -1,9 +1,21 @@
 package org.uniprot.api.proteome.service;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.uniprot.api.common.repository.search.SolrQueryConfig;
 import org.uniprot.api.common.repository.search.SolrQueryConfigFileReader;
+import org.uniprot.api.rest.service.query.QueryProcessor;
+import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
+import org.uniprot.api.rest.validation.config.WhitelistFieldConfig;
+import org.uniprot.store.config.UniProtDataType;
+import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
+import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
+import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 
 @Configuration
 public class ProteomeSolrQueryConfig {
@@ -12,5 +24,23 @@ public class ProteomeSolrQueryConfig {
     @Bean
     public SolrQueryConfig proteomeSolrQueryConf() {
         return new SolrQueryConfigFileReader(RESOURCE_LOCATION).getConfig();
+    }
+
+    @Bean
+    public QueryProcessor proteomeQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+        Map<String, String> proteomeWhiteListFields =
+                whiteListFieldConfig
+                        .getField()
+                        .getOrDefault(
+                                UniProtDataType.PROTEOME.toString().toLowerCase(), new HashMap<>());
+        return new UniProtQueryProcessor(
+                getDefaultSearchOptimisedFieldItems(), proteomeWhiteListFields);
+    }
+
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
+        SearchFieldConfig searchFieldConfig =
+                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.PROTEOME);
+        return Collections.singletonList(
+                searchFieldConfig.getSearchFieldItemByName(ProteomeQueryService.PROTEOME_ID_FIELD));
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/crossref/config/CrossRefSolrQueryConfig.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/crossref/config/CrossRefSolrQueryConfig.java
@@ -28,20 +28,28 @@ public class CrossRefSolrQueryConfig {
     }
 
     @Bean
-    public QueryProcessor crossRefQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+    public SearchFieldConfig crossRefSearchFieldConfig() {
+        return SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.CROSSREF);
+    }
+
+    @Bean
+    public QueryProcessor crossRefQueryProcessor(
+            WhitelistFieldConfig whiteListFieldConfig,
+            SearchFieldConfig crossRefSearchFieldConfig) {
         Map<String, String> crossRefWhiteListFields =
                 whiteListFieldConfig
                         .getField()
                         .getOrDefault(
                                 UniProtDataType.CROSSREF.toString().toLowerCase(), new HashMap<>());
         return new UniProtQueryProcessor(
-                getDefaultSearchOptimisedFieldItems(), crossRefWhiteListFields);
+                getDefaultSearchOptimisedFieldItems(crossRefSearchFieldConfig),
+                crossRefWhiteListFields);
     }
 
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        SearchFieldConfig searchFieldConfig =
-                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.CROSSREF);
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems(
+            SearchFieldConfig crossRefSearchFieldConfig) {
         return Collections.singletonList(
-                searchFieldConfig.getSearchFieldItemByName(CrossRefService.CROSS_REF_ID_FIELD));
+                crossRefSearchFieldConfig.getSearchFieldItemByName(
+                        CrossRefService.CROSS_REF_ID_FIELD));
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/crossref/config/CrossRefSolrQueryConfig.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/crossref/config/CrossRefSolrQueryConfig.java
@@ -1,9 +1,22 @@
 package org.uniprot.api.support.data.crossref.config;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.uniprot.api.common.repository.search.SolrQueryConfig;
 import org.uniprot.api.common.repository.search.SolrQueryConfigFileReader;
+import org.uniprot.api.rest.service.query.QueryProcessor;
+import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
+import org.uniprot.api.rest.validation.config.WhitelistFieldConfig;
+import org.uniprot.api.support.data.crossref.service.CrossRefService;
+import org.uniprot.store.config.UniProtDataType;
+import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
+import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
+import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 
 @Configuration
 public class CrossRefSolrQueryConfig {
@@ -12,5 +25,23 @@ public class CrossRefSolrQueryConfig {
     @Bean
     public SolrQueryConfig crossRefSolrQueryConf() {
         return new SolrQueryConfigFileReader(RESOURCE_LOCATION).getConfig();
+    }
+
+    @Bean
+    public QueryProcessor crossRefQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+        Map<String, String> crossRefWhiteListFields =
+                whiteListFieldConfig
+                        .getField()
+                        .getOrDefault(
+                                UniProtDataType.CROSSREF.toString().toLowerCase(), new HashMap<>());
+        return new UniProtQueryProcessor(
+                getDefaultSearchOptimisedFieldItems(), crossRefWhiteListFields);
+    }
+
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
+        SearchFieldConfig searchFieldConfig =
+                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.CROSSREF);
+        return Collections.singletonList(
+                searchFieldConfig.getSearchFieldItemByName(CrossRefService.CROSS_REF_ID_FIELD));
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/crossref/service/CrossRefService.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/crossref/service/CrossRefService.java
@@ -10,9 +10,7 @@ import org.uniprot.api.support.data.crossref.config.CrossRefSolrQueryConfig;
 import org.uniprot.api.support.data.crossref.repository.CrossRefRepository;
 import org.uniprot.api.support.data.crossref.request.CrossRefEntryConverter;
 import org.uniprot.core.cv.xdb.CrossRefEntry;
-import org.uniprot.store.config.UniProtDataType;
 import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
-import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
 import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 import org.uniprot.store.search.document.dbxref.CrossRefDocument;
 
@@ -29,15 +27,15 @@ public class CrossRefService extends BasicSearchService<CrossRefDocument, CrossR
             CrossRefSolrSortClause crossRefSolrSortClause,
             CrossRefFacetConfig crossRefFacetConfig,
             SolrQueryConfig crossRefSolrQueryConf,
-            QueryProcessor crossRefQueryProcessor) {
+            QueryProcessor crossRefQueryProcessor,
+            SearchFieldConfig crossRefSearchFieldConfig) {
         super(
                 crossRefRepository,
                 toCrossRefEntryConverter,
                 crossRefSolrSortClause,
                 crossRefSolrQueryConf,
                 crossRefFacetConfig);
-        this.searchFieldConfig =
-                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.CROSSREF);
+        this.searchFieldConfig = crossRefSearchFieldConfig;
         this.queryProcessor = crossRefQueryProcessor;
     }
 

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/crossref/service/CrossRefService.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/crossref/service/CrossRefService.java
@@ -1,14 +1,10 @@
 package org.uniprot.api.support.data.crossref.service;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Service;
 import org.uniprot.api.common.repository.search.SolrQueryConfig;
 import org.uniprot.api.rest.service.BasicSearchService;
 import org.uniprot.api.rest.service.query.QueryProcessor;
-import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
 import org.uniprot.api.support.data.crossref.config.CrossRefFacetConfig;
 import org.uniprot.api.support.data.crossref.config.CrossRefSolrQueryConfig;
 import org.uniprot.api.support.data.crossref.repository.CrossRefRepository;
@@ -23,7 +19,7 @@ import org.uniprot.store.search.document.dbxref.CrossRefDocument;
 @Service
 @Import(CrossRefSolrQueryConfig.class)
 public class CrossRefService extends BasicSearchService<CrossRefDocument, CrossRefEntry> {
-    private static final String CROSS_REF_ID_FIELD = "id";
+    public static final String CROSS_REF_ID_FIELD = "id";
     private final SearchFieldConfig searchFieldConfig;
     private final QueryProcessor queryProcessor;
 
@@ -32,7 +28,8 @@ public class CrossRefService extends BasicSearchService<CrossRefDocument, CrossR
             CrossRefEntryConverter toCrossRefEntryConverter,
             CrossRefSolrSortClause crossRefSolrSortClause,
             CrossRefFacetConfig crossRefFacetConfig,
-            SolrQueryConfig crossRefSolrQueryConf) {
+            SolrQueryConfig crossRefSolrQueryConf,
+            QueryProcessor crossRefQueryProcessor) {
         super(
                 crossRefRepository,
                 toCrossRefEntryConverter,
@@ -41,7 +38,7 @@ public class CrossRefService extends BasicSearchService<CrossRefDocument, CrossR
                 crossRefFacetConfig);
         this.searchFieldConfig =
                 SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.CROSSREF);
-        this.queryProcessor = new UniProtQueryProcessor(getDefaultSearchOptimisedFieldItems());
+        this.queryProcessor = crossRefQueryProcessor;
     }
 
     @Override
@@ -52,9 +49,5 @@ public class CrossRefService extends BasicSearchService<CrossRefDocument, CrossR
     @Override
     protected QueryProcessor getQueryProcessor() {
         return queryProcessor;
-    }
-
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        return Collections.singletonList(getIdField());
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/disease/DiseaseService.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/disease/DiseaseService.java
@@ -1,14 +1,10 @@
 package org.uniprot.api.support.data.disease;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Service;
 import org.uniprot.api.common.repository.search.SolrQueryConfig;
 import org.uniprot.api.rest.service.BasicSearchService;
 import org.uniprot.api.rest.service.query.QueryProcessor;
-import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
 import org.uniprot.core.cv.disease.DiseaseEntry;
 import org.uniprot.store.config.UniProtDataType;
 import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
@@ -19,7 +15,7 @@ import org.uniprot.store.search.document.disease.DiseaseDocument;
 @Service
 @Import(DiseaseSolrQueryConfig.class)
 public class DiseaseService extends BasicSearchService<DiseaseDocument, DiseaseEntry> {
-    private static final String DISEASE_ID_FIELD = "id";
+    public static final String DISEASE_ID_FIELD = "id";
     private final SearchFieldConfig searchFieldConfig;
     private final QueryProcessor queryProcessor;
 
@@ -27,7 +23,8 @@ public class DiseaseService extends BasicSearchService<DiseaseDocument, DiseaseE
             DiseaseRepository diseaseRepository,
             DiseaseDocumentToDiseaseConverter toDiseaseConverter,
             DiseaseSolrSortClause diseaseSolrSortClause,
-            SolrQueryConfig diseaseSolrQueryConf) {
+            SolrQueryConfig diseaseSolrQueryConf,
+            QueryProcessor diseaseQueryProcessor) {
 
         super(
                 diseaseRepository,
@@ -37,7 +34,7 @@ public class DiseaseService extends BasicSearchService<DiseaseDocument, DiseaseE
                 null);
         this.searchFieldConfig =
                 SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.DISEASE);
-        this.queryProcessor = new UniProtQueryProcessor(getDefaultSearchOptimisedFieldItems());
+        this.queryProcessor = diseaseQueryProcessor;
     }
 
     @Override
@@ -48,9 +45,5 @@ public class DiseaseService extends BasicSearchService<DiseaseDocument, DiseaseE
     @Override
     protected QueryProcessor getQueryProcessor() {
         return queryProcessor;
-    }
-
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        return Collections.singletonList(getIdField());
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/disease/DiseaseService.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/disease/DiseaseService.java
@@ -6,9 +6,7 @@ import org.uniprot.api.common.repository.search.SolrQueryConfig;
 import org.uniprot.api.rest.service.BasicSearchService;
 import org.uniprot.api.rest.service.query.QueryProcessor;
 import org.uniprot.core.cv.disease.DiseaseEntry;
-import org.uniprot.store.config.UniProtDataType;
 import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
-import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
 import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 import org.uniprot.store.search.document.disease.DiseaseDocument;
 
@@ -24,7 +22,8 @@ public class DiseaseService extends BasicSearchService<DiseaseDocument, DiseaseE
             DiseaseDocumentToDiseaseConverter toDiseaseConverter,
             DiseaseSolrSortClause diseaseSolrSortClause,
             SolrQueryConfig diseaseSolrQueryConf,
-            QueryProcessor diseaseQueryProcessor) {
+            QueryProcessor diseaseQueryProcessor,
+            SearchFieldConfig diseaseSearchFieldConfig) {
 
         super(
                 diseaseRepository,
@@ -32,8 +31,7 @@ public class DiseaseService extends BasicSearchService<DiseaseDocument, DiseaseE
                 diseaseSolrSortClause,
                 diseaseSolrQueryConf,
                 null);
-        this.searchFieldConfig =
-                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.DISEASE);
+        this.searchFieldConfig = diseaseSearchFieldConfig;
         this.queryProcessor = diseaseQueryProcessor;
     }
 

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/disease/DiseaseSolrQueryConfig.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/disease/DiseaseSolrQueryConfig.java
@@ -1,9 +1,21 @@
 package org.uniprot.api.support.data.disease;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.uniprot.api.common.repository.search.SolrQueryConfig;
 import org.uniprot.api.common.repository.search.SolrQueryConfigFileReader;
+import org.uniprot.api.rest.service.query.QueryProcessor;
+import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
+import org.uniprot.api.rest.validation.config.WhitelistFieldConfig;
+import org.uniprot.store.config.UniProtDataType;
+import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
+import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
+import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 
 @Configuration
 public class DiseaseSolrQueryConfig {
@@ -12,5 +24,23 @@ public class DiseaseSolrQueryConfig {
     @Bean
     public SolrQueryConfig diseaseSolrQueryConf() {
         return new SolrQueryConfigFileReader(RESOURCE_LOCATION).getConfig();
+    }
+
+    @Bean
+    public QueryProcessor diseaseQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+        Map<String, String> diseaseWhitelistFields =
+                whiteListFieldConfig
+                        .getField()
+                        .getOrDefault(
+                                UniProtDataType.DISEASE.toString().toLowerCase(), new HashMap<>());
+        return new UniProtQueryProcessor(
+                getDefaultSearchOptimisedFieldItems(), diseaseWhitelistFields);
+    }
+
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
+        SearchFieldConfig searchFieldConfig =
+                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.DISEASE);
+        return Collections.singletonList(
+                searchFieldConfig.getSearchFieldItemByName(DiseaseService.DISEASE_ID_FIELD));
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/disease/DiseaseSolrQueryConfig.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/disease/DiseaseSolrQueryConfig.java
@@ -27,20 +27,26 @@ public class DiseaseSolrQueryConfig {
     }
 
     @Bean
-    public QueryProcessor diseaseQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+    public SearchFieldConfig diseaseSearchFieldConfig() {
+        return SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.DISEASE);
+    }
+
+    @Bean
+    public QueryProcessor diseaseQueryProcessor(
+            WhitelistFieldConfig whiteListFieldConfig, SearchFieldConfig diseaseSearchFieldConfig) {
         Map<String, String> diseaseWhitelistFields =
                 whiteListFieldConfig
                         .getField()
                         .getOrDefault(
                                 UniProtDataType.DISEASE.toString().toLowerCase(), new HashMap<>());
         return new UniProtQueryProcessor(
-                getDefaultSearchOptimisedFieldItems(), diseaseWhitelistFields);
+                getDefaultSearchOptimisedFieldItems(diseaseSearchFieldConfig),
+                diseaseWhitelistFields);
     }
 
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        SearchFieldConfig searchFieldConfig =
-                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.DISEASE);
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems(
+            SearchFieldConfig diseaseSearchFieldConfig) {
         return Collections.singletonList(
-                searchFieldConfig.getSearchFieldItemByName(DiseaseService.DISEASE_ID_FIELD));
+                diseaseSearchFieldConfig.getSearchFieldItemByName(DiseaseService.DISEASE_ID_FIELD));
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/keyword/service/KeywordService.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/keyword/service/KeywordService.java
@@ -7,9 +7,7 @@ import org.uniprot.api.rest.service.BasicSearchService;
 import org.uniprot.api.rest.service.query.QueryProcessor;
 import org.uniprot.api.support.data.keyword.KeywordRepository;
 import org.uniprot.core.cv.keyword.KeywordEntry;
-import org.uniprot.store.config.UniProtDataType;
 import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
-import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
 import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 import org.uniprot.store.search.document.keyword.KeywordDocument;
 
@@ -25,9 +23,10 @@ public class KeywordService extends BasicSearchService<KeywordDocument, KeywordE
             KeywordEntryConverter keywordEntryConverter,
             KeywordSortClause keywordSortClause,
             SolrQueryConfig keywordSolrQueryConf,
-            QueryProcessor keywordQueryProcessor) {
+            QueryProcessor keywordQueryProcessor,
+            SearchFieldConfig keywordSearchFieldConfig) {
         super(repository, keywordEntryConverter, keywordSortClause, keywordSolrQueryConf, null);
-        this.fieldConfig = SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.KEYWORD);
+        this.fieldConfig = keywordSearchFieldConfig;
         this.queryProcessor = keywordQueryProcessor;
     }
 

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/keyword/service/KeywordService.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/keyword/service/KeywordService.java
@@ -1,14 +1,10 @@
 package org.uniprot.api.support.data.keyword.service;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Service;
 import org.uniprot.api.common.repository.search.SolrQueryConfig;
 import org.uniprot.api.rest.service.BasicSearchService;
 import org.uniprot.api.rest.service.query.QueryProcessor;
-import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
 import org.uniprot.api.support.data.keyword.KeywordRepository;
 import org.uniprot.core.cv.keyword.KeywordEntry;
 import org.uniprot.store.config.UniProtDataType;
@@ -20,7 +16,7 @@ import org.uniprot.store.search.document.keyword.KeywordDocument;
 @Service
 @Import(KeywordSolrQueryConfig.class)
 public class KeywordService extends BasicSearchService<KeywordDocument, KeywordEntry> {
-    private static final String KEYWORD_ID_FIELD = "keyword_id";
+    public static final String KEYWORD_ID_FIELD = "keyword_id";
     private final SearchFieldConfig fieldConfig;
     private final QueryProcessor queryProcessor;
 
@@ -28,10 +24,11 @@ public class KeywordService extends BasicSearchService<KeywordDocument, KeywordE
             KeywordRepository repository,
             KeywordEntryConverter keywordEntryConverter,
             KeywordSortClause keywordSortClause,
-            SolrQueryConfig keywordSolrQueryConf) {
+            SolrQueryConfig keywordSolrQueryConf,
+            QueryProcessor keywordQueryProcessor) {
         super(repository, keywordEntryConverter, keywordSortClause, keywordSolrQueryConf, null);
         this.fieldConfig = SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.KEYWORD);
-        this.queryProcessor = new UniProtQueryProcessor(getDefaultSearchOptimisedFieldItems());
+        this.queryProcessor = keywordQueryProcessor;
     }
 
     @Override
@@ -42,9 +39,5 @@ public class KeywordService extends BasicSearchService<KeywordDocument, KeywordE
     @Override
     protected QueryProcessor getQueryProcessor() {
         return queryProcessor;
-    }
-
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        return Collections.singletonList(getIdField());
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/keyword/service/KeywordSolrQueryConfig.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/keyword/service/KeywordSolrQueryConfig.java
@@ -1,9 +1,21 @@
 package org.uniprot.api.support.data.keyword.service;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.uniprot.api.common.repository.search.SolrQueryConfig;
 import org.uniprot.api.common.repository.search.SolrQueryConfigFileReader;
+import org.uniprot.api.rest.service.query.QueryProcessor;
+import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
+import org.uniprot.api.rest.validation.config.WhitelistFieldConfig;
+import org.uniprot.store.config.UniProtDataType;
+import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
+import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
+import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 
 @Configuration
 public class KeywordSolrQueryConfig {
@@ -12,5 +24,23 @@ public class KeywordSolrQueryConfig {
     @Bean
     public SolrQueryConfig keywordSolrQueryConf() {
         return new SolrQueryConfigFileReader(RESOURCE_LOCATION).getConfig();
+    }
+
+    @Bean
+    public QueryProcessor keywordQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+        Map<String, String> keywordWhiteListFields =
+                whiteListFieldConfig
+                        .getField()
+                        .getOrDefault(
+                                UniProtDataType.KEYWORD.toString().toLowerCase(), new HashMap<>());
+        return new UniProtQueryProcessor(
+                getDefaultSearchOptimisedFieldItems(), keywordWhiteListFields);
+    }
+
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
+        SearchFieldConfig searchFieldConfig =
+                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.KEYWORD);
+        return Collections.singletonList(
+                searchFieldConfig.getSearchFieldItemByName(KeywordService.KEYWORD_ID_FIELD));
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/keyword/service/KeywordSolrQueryConfig.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/keyword/service/KeywordSolrQueryConfig.java
@@ -27,20 +27,26 @@ public class KeywordSolrQueryConfig {
     }
 
     @Bean
-    public QueryProcessor keywordQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+    public SearchFieldConfig keywordSearchFieldConfig() {
+        return SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.KEYWORD);
+    }
+
+    @Bean
+    public QueryProcessor keywordQueryProcessor(
+            WhitelistFieldConfig whiteListFieldConfig, SearchFieldConfig keywordSearchFieldConfig) {
         Map<String, String> keywordWhiteListFields =
                 whiteListFieldConfig
                         .getField()
                         .getOrDefault(
                                 UniProtDataType.KEYWORD.toString().toLowerCase(), new HashMap<>());
         return new UniProtQueryProcessor(
-                getDefaultSearchOptimisedFieldItems(), keywordWhiteListFields);
+                getDefaultSearchOptimisedFieldItems(keywordSearchFieldConfig),
+                keywordWhiteListFields);
     }
 
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        SearchFieldConfig searchFieldConfig =
-                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.KEYWORD);
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems(
+            SearchFieldConfig keywordSearchFieldConfig) {
         return Collections.singletonList(
-                searchFieldConfig.getSearchFieldItemByName(KeywordService.KEYWORD_ID_FIELD));
+                keywordSearchFieldConfig.getSearchFieldItemByName(KeywordService.KEYWORD_ID_FIELD));
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/literature/service/LiteratureService.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/literature/service/LiteratureService.java
@@ -8,9 +8,7 @@ import org.uniprot.api.rest.service.query.QueryProcessor;
 import org.uniprot.api.support.data.literature.repository.LiteratureFacetConfig;
 import org.uniprot.api.support.data.literature.repository.LiteratureRepository;
 import org.uniprot.core.literature.LiteratureEntry;
-import org.uniprot.store.config.UniProtDataType;
 import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
-import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
 import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 import org.uniprot.store.search.document.literature.LiteratureDocument;
 
@@ -31,15 +29,15 @@ public class LiteratureService extends BasicSearchService<LiteratureDocument, Li
             LiteratureFacetConfig facetConfig,
             LiteratureSortClause literatureSortClause,
             SolrQueryConfig literatureSolrQueryConf,
-            QueryProcessor literatureQueryProcessor) {
+            QueryProcessor literatureQueryProcessor,
+            SearchFieldConfig literatureSearchFieldConfig) {
         super(
                 repository,
                 entryConverter,
                 literatureSortClause,
                 literatureSolrQueryConf,
                 facetConfig);
-        this.searchFieldConfig =
-                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.LITERATURE);
+        this.searchFieldConfig = literatureSearchFieldConfig;
         this.queryProcessor = literatureQueryProcessor;
     }
 

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/literature/service/LiteratureService.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/literature/service/LiteratureService.java
@@ -1,14 +1,10 @@
 package org.uniprot.api.support.data.literature.service;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Service;
 import org.uniprot.api.common.repository.search.SolrQueryConfig;
 import org.uniprot.api.rest.service.BasicSearchService;
 import org.uniprot.api.rest.service.query.QueryProcessor;
-import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
 import org.uniprot.api.support.data.literature.repository.LiteratureFacetConfig;
 import org.uniprot.api.support.data.literature.repository.LiteratureRepository;
 import org.uniprot.core.literature.LiteratureEntry;
@@ -25,7 +21,7 @@ import org.uniprot.store.search.document.literature.LiteratureDocument;
 @Service
 @Import(LiteratureSolrQueryConfig.class)
 public class LiteratureService extends BasicSearchService<LiteratureDocument, LiteratureEntry> {
-    private static final String LITERATURE_ID_FIELD = "id";
+    public static final String LITERATURE_ID_FIELD = "id";
     private final SearchFieldConfig searchFieldConfig;
     private final QueryProcessor queryProcessor;
 
@@ -34,7 +30,8 @@ public class LiteratureService extends BasicSearchService<LiteratureDocument, Li
             LiteratureEntryConverter entryConverter,
             LiteratureFacetConfig facetConfig,
             LiteratureSortClause literatureSortClause,
-            SolrQueryConfig literatureSolrQueryConf) {
+            SolrQueryConfig literatureSolrQueryConf,
+            QueryProcessor literatureQueryProcessor) {
         super(
                 repository,
                 entryConverter,
@@ -43,7 +40,7 @@ public class LiteratureService extends BasicSearchService<LiteratureDocument, Li
                 facetConfig);
         this.searchFieldConfig =
                 SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.LITERATURE);
-        this.queryProcessor = new UniProtQueryProcessor(getDefaultSearchOptimisedFieldItems());
+        this.queryProcessor = literatureQueryProcessor;
     }
 
     @Override
@@ -54,9 +51,5 @@ public class LiteratureService extends BasicSearchService<LiteratureDocument, Li
     @Override
     protected QueryProcessor getQueryProcessor() {
         return queryProcessor;
-    }
-
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        return Collections.singletonList(getIdField());
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/literature/service/LiteratureSolrQueryConfig.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/literature/service/LiteratureSolrQueryConfig.java
@@ -1,9 +1,21 @@
 package org.uniprot.api.support.data.literature.service;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.uniprot.api.common.repository.search.SolrQueryConfig;
 import org.uniprot.api.common.repository.search.SolrQueryConfigFileReader;
+import org.uniprot.api.rest.service.query.QueryProcessor;
+import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
+import org.uniprot.api.rest.validation.config.WhitelistFieldConfig;
+import org.uniprot.store.config.UniProtDataType;
+import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
+import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
+import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 
 @Configuration
 public class LiteratureSolrQueryConfig {
@@ -12,5 +24,24 @@ public class LiteratureSolrQueryConfig {
     @Bean
     public SolrQueryConfig literatureSolrQueryConf() {
         return new SolrQueryConfigFileReader(RESOURCE_LOCATION).getConfig();
+    }
+
+    @Bean
+    public QueryProcessor literatureQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+        Map<String, String> literatureWhiteListFields =
+                whiteListFieldConfig
+                        .getField()
+                        .getOrDefault(
+                                UniProtDataType.LITERATURE.toString().toLowerCase(),
+                                new HashMap<>());
+        return new UniProtQueryProcessor(
+                getDefaultSearchOptimisedFieldItems(), literatureWhiteListFields);
+    }
+
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
+        SearchFieldConfig searchFieldConfig =
+                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.LITERATURE);
+        return Collections.singletonList(
+                searchFieldConfig.getSearchFieldItemByName(LiteratureService.LITERATURE_ID_FIELD));
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/literature/service/LiteratureSolrQueryConfig.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/literature/service/LiteratureSolrQueryConfig.java
@@ -27,7 +27,14 @@ public class LiteratureSolrQueryConfig {
     }
 
     @Bean
-    public QueryProcessor literatureQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+    public SearchFieldConfig literatureSearchFieldConfig() {
+        return SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.LITERATURE);
+    }
+
+    @Bean
+    public QueryProcessor literatureQueryProcessor(
+            WhitelistFieldConfig whiteListFieldConfig,
+            SearchFieldConfig literatureSearchFieldConfig) {
         Map<String, String> literatureWhiteListFields =
                 whiteListFieldConfig
                         .getField()
@@ -35,13 +42,14 @@ public class LiteratureSolrQueryConfig {
                                 UniProtDataType.LITERATURE.toString().toLowerCase(),
                                 new HashMap<>());
         return new UniProtQueryProcessor(
-                getDefaultSearchOptimisedFieldItems(), literatureWhiteListFields);
+                getDefaultSearchOptimisedFieldItems(literatureSearchFieldConfig),
+                literatureWhiteListFields);
     }
 
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        SearchFieldConfig searchFieldConfig =
-                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.LITERATURE);
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems(
+            SearchFieldConfig literatureSearchFieldConfig) {
         return Collections.singletonList(
-                searchFieldConfig.getSearchFieldItemByName(LiteratureService.LITERATURE_ID_FIELD));
+                literatureSearchFieldConfig.getSearchFieldItemByName(
+                        LiteratureService.LITERATURE_ID_FIELD));
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/subcell/service/SubcellularLocationService.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/subcell/service/SubcellularLocationService.java
@@ -7,9 +7,7 @@ import org.uniprot.api.rest.service.BasicSearchService;
 import org.uniprot.api.rest.service.query.QueryProcessor;
 import org.uniprot.api.support.data.subcell.SubcellularLocationRepository;
 import org.uniprot.core.cv.subcell.SubcellularLocationEntry;
-import org.uniprot.store.config.UniProtDataType;
 import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
-import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
 import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 import org.uniprot.store.search.document.subcell.SubcellularLocationDocument;
 
@@ -30,15 +28,15 @@ public class SubcellularLocationService
             SubcellularLocationEntryConverter subcellularLocationEntryConverter,
             SubcellularLocationSortClause subcellularLocationSortClause,
             SolrQueryConfig subcellSolrQueryConf,
-            QueryProcessor subcellQueryProcessor) {
+            QueryProcessor subcellQueryProcessor,
+            SearchFieldConfig subcellSearchFieldConfig) {
         super(
                 repository,
                 subcellularLocationEntryConverter,
                 subcellularLocationSortClause,
                 subcellSolrQueryConf,
                 null);
-        this.searchFieldConfig =
-                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.SUBCELLLOCATION);
+        this.searchFieldConfig = subcellSearchFieldConfig;
         this.queryProcessor = subcellQueryProcessor;
     }
 

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/subcell/service/SubcellularLocationService.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/subcell/service/SubcellularLocationService.java
@@ -1,14 +1,10 @@
 package org.uniprot.api.support.data.subcell.service;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Service;
 import org.uniprot.api.common.repository.search.SolrQueryConfig;
 import org.uniprot.api.rest.service.BasicSearchService;
 import org.uniprot.api.rest.service.query.QueryProcessor;
-import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
 import org.uniprot.api.support.data.subcell.SubcellularLocationRepository;
 import org.uniprot.core.cv.subcell.SubcellularLocationEntry;
 import org.uniprot.store.config.UniProtDataType;
@@ -25,7 +21,7 @@ import org.uniprot.store.search.document.subcell.SubcellularLocationDocument;
 @Import(SubcellularLocationSolrQueryConfig.class)
 public class SubcellularLocationService
         extends BasicSearchService<SubcellularLocationDocument, SubcellularLocationEntry> {
-    private static final String SUBCELL_ID_FIELD = "id";
+    public static final String SUBCELL_ID_FIELD = "id";
     private final SearchFieldConfig searchFieldConfig;
     private final QueryProcessor queryProcessor;
 
@@ -33,7 +29,8 @@ public class SubcellularLocationService
             SubcellularLocationRepository repository,
             SubcellularLocationEntryConverter subcellularLocationEntryConverter,
             SubcellularLocationSortClause subcellularLocationSortClause,
-            SolrQueryConfig subcellSolrQueryConf) {
+            SolrQueryConfig subcellSolrQueryConf,
+            QueryProcessor subcellQueryProcessor) {
         super(
                 repository,
                 subcellularLocationEntryConverter,
@@ -42,8 +39,7 @@ public class SubcellularLocationService
                 null);
         this.searchFieldConfig =
                 SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.SUBCELLLOCATION);
-        this.queryProcessor = new UniProtQueryProcessor(getDefaultSearchOptimisedFieldItems());
-        ;
+        this.queryProcessor = subcellQueryProcessor;
     }
 
     @Override
@@ -54,9 +50,5 @@ public class SubcellularLocationService
     @Override
     protected QueryProcessor getQueryProcessor() {
         return queryProcessor;
-    }
-
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        return Collections.singletonList(getIdField());
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/subcell/service/SubcellularLocationSolrQueryConfig.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/subcell/service/SubcellularLocationSolrQueryConfig.java
@@ -27,7 +27,13 @@ public class SubcellularLocationSolrQueryConfig {
     }
 
     @Bean
-    public QueryProcessor subcellQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+    public SearchFieldConfig subcellSearchFieldConfig() {
+        return SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.SUBCELLLOCATION);
+    }
+
+    @Bean
+    public QueryProcessor subcellQueryProcessor(
+            WhitelistFieldConfig whiteListFieldConfig, SearchFieldConfig subcellSearchFieldConfig) {
         Map<String, String> subcellWhiteListFields =
                 whiteListFieldConfig
                         .getField()
@@ -35,12 +41,12 @@ public class SubcellularLocationSolrQueryConfig {
                                 UniProtDataType.SUBCELLLOCATION.toString().toLowerCase(),
                                 new HashMap<>());
         return new UniProtQueryProcessor(
-                getDefaultSearchOptimisedFieldItems(), subcellWhiteListFields);
+                getDefaultSearchOptimisedFieldItems(subcellSearchFieldConfig),
+                subcellWhiteListFields);
     }
 
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        SearchFieldConfig searchFieldConfig =
-                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.SUBCELLLOCATION);
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems(
+            SearchFieldConfig searchFieldConfig) {
         return Collections.singletonList(
                 searchFieldConfig.getSearchFieldItemByName(
                         SubcellularLocationService.SUBCELL_ID_FIELD));

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/subcell/service/SubcellularLocationSolrQueryConfig.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/subcell/service/SubcellularLocationSolrQueryConfig.java
@@ -1,9 +1,21 @@
 package org.uniprot.api.support.data.subcell.service;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.uniprot.api.common.repository.search.SolrQueryConfig;
 import org.uniprot.api.common.repository.search.SolrQueryConfigFileReader;
+import org.uniprot.api.rest.service.query.QueryProcessor;
+import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
+import org.uniprot.api.rest.validation.config.WhitelistFieldConfig;
+import org.uniprot.store.config.UniProtDataType;
+import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
+import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
+import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 
 @Configuration
 public class SubcellularLocationSolrQueryConfig {
@@ -12,5 +24,25 @@ public class SubcellularLocationSolrQueryConfig {
     @Bean
     public SolrQueryConfig subcellSolrQueryConf() {
         return new SolrQueryConfigFileReader(RESOURCE_LOCATION).getConfig();
+    }
+
+    @Bean
+    public QueryProcessor subcellQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+        Map<String, String> subcellWhiteListFields =
+                whiteListFieldConfig
+                        .getField()
+                        .getOrDefault(
+                                UniProtDataType.SUBCELLLOCATION.toString().toLowerCase(),
+                                new HashMap<>());
+        return new UniProtQueryProcessor(
+                getDefaultSearchOptimisedFieldItems(), subcellWhiteListFields);
+    }
+
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
+        SearchFieldConfig searchFieldConfig =
+                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.SUBCELLLOCATION);
+        return Collections.singletonList(
+                searchFieldConfig.getSearchFieldItemByName(
+                        SubcellularLocationService.SUBCELL_ID_FIELD));
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/taxonomy/service/TaxonomyService.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/taxonomy/service/TaxonomyService.java
@@ -8,9 +8,7 @@ import org.uniprot.api.rest.service.query.QueryProcessor;
 import org.uniprot.api.support.data.taxonomy.repository.TaxonomyFacetConfig;
 import org.uniprot.api.support.data.taxonomy.repository.TaxonomyRepository;
 import org.uniprot.core.taxonomy.TaxonomyEntry;
-import org.uniprot.store.config.UniProtDataType;
 import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
-import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
 import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 import org.uniprot.store.search.document.taxonomy.TaxonomyDocument;
 
@@ -27,11 +25,11 @@ public class TaxonomyService extends BasicSearchService<TaxonomyDocument, Taxono
             TaxonomyEntryConverter converter,
             TaxonomySortClause taxonomySortClause,
             SolrQueryConfig taxonomySolrQueryConf,
-            QueryProcessor taxonomyQueryProcessor) {
+            QueryProcessor taxonomyQueryProcessor,
+            SearchFieldConfig taxonomySearchFieldConfig) {
 
         super(repository, converter, taxonomySortClause, taxonomySolrQueryConf, facetConfig);
-        this.searchFieldConfig =
-                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.TAXONOMY);
+        this.searchFieldConfig = taxonomySearchFieldConfig;
         this.queryProcessor = taxonomyQueryProcessor;
     }
 

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/taxonomy/service/TaxonomyService.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/taxonomy/service/TaxonomyService.java
@@ -1,14 +1,10 @@
 package org.uniprot.api.support.data.taxonomy.service;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Service;
 import org.uniprot.api.common.repository.search.SolrQueryConfig;
 import org.uniprot.api.rest.service.BasicSearchService;
 import org.uniprot.api.rest.service.query.QueryProcessor;
-import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
 import org.uniprot.api.support.data.taxonomy.repository.TaxonomyFacetConfig;
 import org.uniprot.api.support.data.taxonomy.repository.TaxonomyRepository;
 import org.uniprot.core.taxonomy.TaxonomyEntry;
@@ -21,7 +17,7 @@ import org.uniprot.store.search.document.taxonomy.TaxonomyDocument;
 @Service
 @Import(TaxonomySolrQueryConfig.class)
 public class TaxonomyService extends BasicSearchService<TaxonomyDocument, TaxonomyEntry> {
-    private static final String TAXONOMY_ID_FIELD = "id";
+    public static final String TAXONOMY_ID_FIELD = "id";
     private final SearchFieldConfig searchFieldConfig;
     private final QueryProcessor queryProcessor;
 
@@ -30,12 +26,13 @@ public class TaxonomyService extends BasicSearchService<TaxonomyDocument, Taxono
             TaxonomyFacetConfig facetConfig,
             TaxonomyEntryConverter converter,
             TaxonomySortClause taxonomySortClause,
-            SolrQueryConfig taxonomySolrQueryConf) {
+            SolrQueryConfig taxonomySolrQueryConf,
+            QueryProcessor taxonomyQueryProcessor) {
 
         super(repository, converter, taxonomySortClause, taxonomySolrQueryConf, facetConfig);
         this.searchFieldConfig =
                 SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.TAXONOMY);
-        this.queryProcessor = new UniProtQueryProcessor(getDefaultSearchOptimisedFieldItems());
+        this.queryProcessor = taxonomyQueryProcessor;
     }
 
     public TaxonomyEntry findById(final long taxId) {
@@ -50,9 +47,5 @@ public class TaxonomyService extends BasicSearchService<TaxonomyDocument, Taxono
     @Override
     protected QueryProcessor getQueryProcessor() {
         return queryProcessor;
-    }
-
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        return Collections.singletonList(getIdField());
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/taxonomy/service/TaxonomySolrQueryConfig.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/taxonomy/service/TaxonomySolrQueryConfig.java
@@ -27,20 +27,28 @@ public class TaxonomySolrQueryConfig {
     }
 
     @Bean
-    public QueryProcessor taxonomyQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+    public SearchFieldConfig taxonomySearchFieldConfig() {
+        return SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.TAXONOMY);
+    }
+
+    @Bean
+    public QueryProcessor taxonomyQueryProcessor(
+            WhitelistFieldConfig whiteListFieldConfig,
+            SearchFieldConfig taxonomySearchFieldConfig) {
         Map<String, String> taxonomyWhiteListFields =
                 whiteListFieldConfig
                         .getField()
                         .getOrDefault(
                                 UniProtDataType.TAXONOMY.toString().toLowerCase(), new HashMap<>());
         return new UniProtQueryProcessor(
-                getDefaultSearchOptimisedFieldItems(), taxonomyWhiteListFields);
+                getDefaultSearchOptimisedFieldItems(taxonomySearchFieldConfig),
+                taxonomyWhiteListFields);
     }
 
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        SearchFieldConfig searchFieldConfig =
-                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.TAXONOMY);
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems(
+            SearchFieldConfig taxonomySearchFieldConfig) {
         return Collections.singletonList(
-                searchFieldConfig.getSearchFieldItemByName(TaxonomyService.TAXONOMY_ID_FIELD));
+                taxonomySearchFieldConfig.getSearchFieldItemByName(
+                        TaxonomyService.TAXONOMY_ID_FIELD));
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/taxonomy/service/TaxonomySolrQueryConfig.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/taxonomy/service/TaxonomySolrQueryConfig.java
@@ -1,9 +1,21 @@
 package org.uniprot.api.support.data.taxonomy.service;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.uniprot.api.common.repository.search.SolrQueryConfig;
 import org.uniprot.api.common.repository.search.SolrQueryConfigFileReader;
+import org.uniprot.api.rest.service.query.QueryProcessor;
+import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
+import org.uniprot.api.rest.validation.config.WhitelistFieldConfig;
+import org.uniprot.store.config.UniProtDataType;
+import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
+import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
+import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 
 @Configuration
 public class TaxonomySolrQueryConfig {
@@ -12,5 +24,23 @@ public class TaxonomySolrQueryConfig {
     @Bean
     public SolrQueryConfig taxonomySolrQueryConf() {
         return new SolrQueryConfigFileReader(RESOURCE_LOCATION).getConfig();
+    }
+
+    @Bean
+    public QueryProcessor taxonomyQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+        Map<String, String> taxonomyWhiteListFields =
+                whiteListFieldConfig
+                        .getField()
+                        .getOrDefault(
+                                UniProtDataType.TAXONOMY.toString().toLowerCase(), new HashMap<>());
+        return new UniProtQueryProcessor(
+                getDefaultSearchOptimisedFieldItems(), taxonomyWhiteListFields);
+    }
+
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
+        SearchFieldConfig searchFieldConfig =
+                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.TAXONOMY);
+        return Collections.singletonList(
+                searchFieldConfig.getSearchFieldItemByName(TaxonomyService.TAXONOMY_ID_FIELD));
     }
 }

--- a/support-data-rest/src/test/java/org/uniprot/api/support/data/taxonomy/TaxonomyGetIdsControllerIT.java
+++ b/support-data-rest/src/test/java/org/uniprot/api/support/data/taxonomy/TaxonomyGetIdsControllerIT.java
@@ -209,9 +209,9 @@ class TaxonomyGetIdsControllerIT {
                 .andExpect(header().string(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON_VALUE))
                 .andExpect(
                         header().string(
-                                "Content-Disposition",
-                                startsWith(
-                                        "form-data; name=\"attachment\"; filename=\"uniprot-")))
+                                        "Content-Disposition",
+                                        startsWith(
+                                                "form-data; name=\"attachment\"; filename=\"uniprot-")))
                 .andExpect(jsonPath("$.results.size()", is(3)))
                 .andExpect(jsonPath("$.results.*.taxonId", contains(9606, 9607, 9608)));
     }
@@ -231,8 +231,9 @@ class TaxonomyGetIdsControllerIT {
                 .andExpect(header().string(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$.results.size()", is(3)))
                 .andExpect(jsonPath("$.results.*.taxonId", contains(9606, 9607, 9608)))
-                .andExpect(jsonPath("$.results.*.commonName", contains("common", "common", "common")))
-                     .andExpect(jsonPath("$.results.*.scientificName").doesNotExist());
+                .andExpect(
+                        jsonPath("$.results.*.commonName", contains("common", "common", "common")))
+                .andExpect(jsonPath("$.results.*.scientificName").doesNotExist());
     }
 
     @Test

--- a/uniparc-rest/src/main/java/org/uniprot/api/uniparc/service/UniParcQueryService.java
+++ b/uniparc-rest/src/main/java/org/uniprot/api/uniparc/service/UniParcQueryService.java
@@ -2,7 +2,6 @@ package org.uniprot.api.uniparc.service;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -17,7 +16,6 @@ import org.uniprot.api.common.repository.search.SolrRequest;
 import org.uniprot.api.common.repository.store.StoreStreamer;
 import org.uniprot.api.rest.service.StoreStreamerSearchService;
 import org.uniprot.api.rest.service.query.QueryProcessor;
-import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
 import org.uniprot.api.uniparc.repository.UniParcFacetConfig;
 import org.uniprot.api.uniparc.repository.UniParcQueryRepository;
 import org.uniprot.api.uniparc.request.*;
@@ -40,7 +38,7 @@ import org.uniprot.store.search.document.uniparc.UniParcDocument;
 @Service
 @Import(UniParcSolrQueryConfig.class)
 public class UniParcQueryService extends StoreStreamerSearchService<UniParcDocument, UniParcEntry> {
-    private static final String UNIPARC_ID_FIELD = "upi";
+    public static final String UNIPARC_ID_FIELD = "upi";
     private static final String ACCESSION_FIELD = "uniprotkb";
     public static final String MD5_STR = "md5";
     private static final String COMMA_STR = ",";
@@ -56,7 +54,8 @@ public class UniParcQueryService extends StoreStreamerSearchService<UniParcDocum
             UniParcSortClause solrSortClause,
             UniParcQueryResultConverter uniParcQueryResultConverter,
             StoreStreamer<UniParcEntry> storeStreamer,
-            SolrQueryConfig uniParcSolrQueryConf) {
+            SolrQueryConfig uniParcSolrQueryConf,
+            QueryProcessor uniParcQueryProcessor) {
 
         super(
                 repository,
@@ -67,7 +66,7 @@ public class UniParcQueryService extends StoreStreamerSearchService<UniParcDocum
                 uniParcSolrQueryConf);
         this.searchFieldConfig =
                 SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.UNIPARC);
-        this.queryProcessor = new UniProtQueryProcessor(getDefaultSearchOptimisedFieldItems());
+        this.queryProcessor = uniParcQueryProcessor;
         this.repository = repository;
         this.entryConverter = uniParcQueryResultConverter;
     }
@@ -140,10 +139,6 @@ public class UniParcQueryService extends StoreStreamerSearchService<UniParcDocum
 
         BestGuessAnalyser analyser = new BestGuessAnalyser(searchFieldConfig);
         return analyser.analyseBestGuess(streamResult, request);
-    }
-
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        return Collections.singletonList(getIdField());
     }
 
     private Stream<UniParcEntry> filterUniParcStream(

--- a/uniparc-rest/src/main/java/org/uniprot/api/uniparc/service/UniParcQueryService.java
+++ b/uniparc-rest/src/main/java/org/uniprot/api/uniparc/service/UniParcQueryService.java
@@ -25,9 +25,7 @@ import org.uniprot.api.uniparc.service.filter.UniParcTaxonomyFilter;
 import org.uniprot.core.uniparc.UniParcEntry;
 import org.uniprot.core.util.MessageDigestUtil;
 import org.uniprot.core.util.Utils;
-import org.uniprot.store.config.UniProtDataType;
 import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
-import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
 import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 import org.uniprot.store.search.document.uniparc.UniParcDocument;
 
@@ -55,7 +53,8 @@ public class UniParcQueryService extends StoreStreamerSearchService<UniParcDocum
             UniParcQueryResultConverter uniParcQueryResultConverter,
             StoreStreamer<UniParcEntry> storeStreamer,
             SolrQueryConfig uniParcSolrQueryConf,
-            QueryProcessor uniParcQueryProcessor) {
+            QueryProcessor uniParcQueryProcessor,
+            SearchFieldConfig uniParcSearchFieldConfig) {
 
         super(
                 repository,
@@ -64,8 +63,7 @@ public class UniParcQueryService extends StoreStreamerSearchService<UniParcDocum
                 facetConfig,
                 storeStreamer,
                 uniParcSolrQueryConf);
-        this.searchFieldConfig =
-                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.UNIPARC);
+        this.searchFieldConfig = uniParcSearchFieldConfig;
         this.queryProcessor = uniParcQueryProcessor;
         this.repository = repository;
         this.entryConverter = uniParcQueryResultConverter;

--- a/uniparc-rest/src/main/java/org/uniprot/api/uniparc/service/UniParcSolrQueryConfig.java
+++ b/uniparc-rest/src/main/java/org/uniprot/api/uniparc/service/UniParcSolrQueryConfig.java
@@ -1,9 +1,21 @@
 package org.uniprot.api.uniparc.service;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.uniprot.api.common.repository.search.SolrQueryConfig;
 import org.uniprot.api.common.repository.search.SolrQueryConfigFileReader;
+import org.uniprot.api.rest.service.query.QueryProcessor;
+import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
+import org.uniprot.api.rest.validation.config.WhitelistFieldConfig;
+import org.uniprot.store.config.UniProtDataType;
+import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
+import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
+import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 
 @Configuration
 public class UniParcSolrQueryConfig {
@@ -12,5 +24,23 @@ public class UniParcSolrQueryConfig {
     @Bean
     public SolrQueryConfig uniParcSolrQueryConf() {
         return new SolrQueryConfigFileReader(RESOURCE_LOCATION).getConfig();
+    }
+
+    @Bean
+    public QueryProcessor uniParcQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+        Map<String, String> uniParcWhiteListFields =
+                whiteListFieldConfig
+                        .getField()
+                        .getOrDefault(
+                                UniProtDataType.UNIPARC.toString().toLowerCase(), new HashMap<>());
+        return new UniProtQueryProcessor(
+                getDefaultSearchOptimisedFieldItems(), uniParcWhiteListFields);
+    }
+
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
+        SearchFieldConfig searchFieldConfig =
+                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.UNIPARC);
+        return Collections.singletonList(
+                searchFieldConfig.getSearchFieldItemByName(UniParcQueryService.UNIPARC_ID_FIELD));
     }
 }

--- a/uniparc-rest/src/main/java/org/uniprot/api/uniparc/service/UniParcSolrQueryConfig.java
+++ b/uniparc-rest/src/main/java/org/uniprot/api/uniparc/service/UniParcSolrQueryConfig.java
@@ -27,20 +27,27 @@ public class UniParcSolrQueryConfig {
     }
 
     @Bean
-    public QueryProcessor uniParcQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+    public SearchFieldConfig uniParcSearchFieldConfig() {
+        return SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.UNIPARC);
+    }
+
+    @Bean
+    public QueryProcessor uniParcQueryProcessor(
+            WhitelistFieldConfig whiteListFieldConfig, SearchFieldConfig uniParcSearchFieldConfig) {
         Map<String, String> uniParcWhiteListFields =
                 whiteListFieldConfig
                         .getField()
                         .getOrDefault(
                                 UniProtDataType.UNIPARC.toString().toLowerCase(), new HashMap<>());
         return new UniProtQueryProcessor(
-                getDefaultSearchOptimisedFieldItems(), uniParcWhiteListFields);
+                getDefaultSearchOptimisedFieldItems(uniParcSearchFieldConfig),
+                uniParcWhiteListFields);
     }
 
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        SearchFieldConfig searchFieldConfig =
-                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.UNIPARC);
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems(
+            SearchFieldConfig uniParcSearchFieldConfig) {
         return Collections.singletonList(
-                searchFieldConfig.getSearchFieldItemByName(UniParcQueryService.UNIPARC_ID_FIELD));
+                uniParcSearchFieldConfig.getSearchFieldItemByName(
+                        UniParcQueryService.UNIPARC_ID_FIELD));
     }
 }

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/repository/search/impl/UniProtSolrQueryConfig.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/repository/search/impl/UniProtSolrQueryConfig.java
@@ -1,9 +1,22 @@
 package org.uniprot.api.uniprotkb.repository.search.impl;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.uniprot.api.common.repository.search.SolrQueryConfig;
 import org.uniprot.api.common.repository.search.SolrQueryConfigFileReader;
+import org.uniprot.api.rest.service.query.QueryProcessor;
+import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
+import org.uniprot.api.rest.validation.config.WhitelistFieldConfig;
+import org.uniprot.api.uniprotkb.service.UniProtEntryService;
+import org.uniprot.store.config.UniProtDataType;
+import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
+import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
+import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 
 /**
  * Created 05/09/19
@@ -17,5 +30,24 @@ public class UniProtSolrQueryConfig {
     @Bean
     public SolrQueryConfig uniProtKBSolrQueryConf() {
         return new SolrQueryConfigFileReader(RESOURCE_LOCATION).getConfig();
+    }
+
+    @Bean
+    public QueryProcessor uniProtKBQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+        Map<String, String> uniprotWhiteListFields =
+                whiteListFieldConfig
+                        .getField()
+                        .getOrDefault(
+                                UniProtDataType.UNIPROTKB.toString().toLowerCase(),
+                                new HashMap<>());
+        return new UniProtQueryProcessor(
+                getDefaultSearchOptimisedFieldItems(), uniprotWhiteListFields);
+    }
+
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
+        SearchFieldConfig searchFieldConfig =
+                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.UNIPROTKB);
+        return Collections.singletonList(
+                searchFieldConfig.getSearchFieldItemByName(UniProtEntryService.ACCESSION));
     }
 }

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/repository/search/impl/UniProtSolrQueryConfig.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/repository/search/impl/UniProtSolrQueryConfig.java
@@ -33,7 +33,14 @@ public class UniProtSolrQueryConfig {
     }
 
     @Bean
-    public QueryProcessor uniProtKBQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+    public SearchFieldConfig uniProtKBSearchFieldConfig() {
+        return SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.UNIPROTKB);
+    }
+
+    @Bean
+    public QueryProcessor uniProtKBQueryProcessor(
+            WhitelistFieldConfig whiteListFieldConfig,
+            SearchFieldConfig uniProtKBSearchFieldConfig) {
         Map<String, String> uniprotWhiteListFields =
                 whiteListFieldConfig
                         .getField()
@@ -41,13 +48,13 @@ public class UniProtSolrQueryConfig {
                                 UniProtDataType.UNIPROTKB.toString().toLowerCase(),
                                 new HashMap<>());
         return new UniProtQueryProcessor(
-                getDefaultSearchOptimisedFieldItems(), uniprotWhiteListFields);
+                getDefaultSearchOptimisedFieldItems(uniProtKBSearchFieldConfig),
+                uniprotWhiteListFields);
     }
 
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        SearchFieldConfig searchFieldConfig =
-                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.UNIPROTKB);
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems(
+            SearchFieldConfig uniProtKBSearchFieldConfig) {
         return Collections.singletonList(
-                searchFieldConfig.getSearchFieldItemByName(UniProtEntryService.ACCESSION));
+                uniProtKBSearchFieldConfig.getSearchFieldItemByName(UniProtEntryService.ACCESSION));
     }
 }

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/service/UniProtEntryService.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/service/UniProtEntryService.java
@@ -39,7 +39,6 @@ import org.uniprot.store.config.returnfield.config.ReturnFieldConfig;
 import org.uniprot.store.config.returnfield.factory.ReturnFieldConfigFactory;
 import org.uniprot.store.config.returnfield.model.ReturnField;
 import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
-import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
 import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 import org.uniprot.store.search.SolrQueryUtil;
 import org.uniprot.store.search.document.uniprot.UniProtDocument;
@@ -70,7 +69,8 @@ public class UniProtEntryService
             StoreStreamer<UniProtKBEntry> uniProtEntryStoreStreamer,
             TaxonomyService taxService,
             FacetTupleStreamTemplate facetTupleStreamTemplate,
-            QueryProcessor uniProtKBQueryProcessor) {
+            QueryProcessor uniProtKBQueryProcessor,
+            SearchFieldConfig uniProtKBSearchFieldConfig) {
         super(
                 repository,
                 uniprotKBFacetConfig,
@@ -82,8 +82,7 @@ public class UniProtEntryService
         this.solrQueryConfig = uniProtKBSolrQueryConf;
         this.resultsConverter = new UniProtEntryQueryResultsConverter(entryStore, taxService);
         this.storeStreamer = uniProtEntryStoreStreamer;
-        this.searchFieldConfig =
-                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.UNIPROTKB);
+        this.searchFieldConfig = uniProtKBSearchFieldConfig;
         this.returnFieldConfig =
                 ReturnFieldConfigFactory.getReturnFieldConfig(UniProtDataType.UNIPROTKB);
         this.queryProcessor = uniProtKBQueryProcessor;

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/service/UniProtEntryService.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/service/UniProtEntryService.java
@@ -24,7 +24,6 @@ import org.uniprot.api.rest.request.SearchRequest;
 import org.uniprot.api.rest.request.StreamRequest;
 import org.uniprot.api.rest.service.StoreStreamerSearchService;
 import org.uniprot.api.rest.service.query.QueryProcessor;
-import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
 import org.uniprot.api.uniprotkb.controller.request.GetByAccessionsRequest;
 import org.uniprot.api.uniprotkb.controller.request.UniProtKBSearchRequest;
 import org.uniprot.api.uniprotkb.controller.request.UniProtKBStreamRequest;
@@ -49,7 +48,7 @@ import org.uniprot.store.search.document.uniprot.UniProtDocument;
 @Import(UniProtSolrQueryConfig.class)
 public class UniProtEntryService
         extends StoreStreamerSearchService<UniProtDocument, UniProtKBEntry> {
-    private static final String ACCESSION = "accession_id";
+    public static final String ACCESSION = "accession_id";
     private final UniProtEntryQueryResultsConverter resultsConverter;
     private final SolrQueryConfig solrQueryConfig;
     private final UniProtTermsConfig uniProtTermsConfig;
@@ -70,7 +69,8 @@ public class UniProtEntryService
             UniProtKBStoreClient entryStore,
             StoreStreamer<UniProtKBEntry> uniProtEntryStoreStreamer,
             TaxonomyService taxService,
-            FacetTupleStreamTemplate facetTupleStreamTemplate) {
+            FacetTupleStreamTemplate facetTupleStreamTemplate,
+            QueryProcessor uniProtKBQueryProcessor) {
         super(
                 repository,
                 uniprotKBFacetConfig,
@@ -86,7 +86,7 @@ public class UniProtEntryService
                 SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.UNIPROTKB);
         this.returnFieldConfig =
                 ReturnFieldConfigFactory.getReturnFieldConfig(UniProtDataType.UNIPROTKB);
-        this.queryProcessor = new UniProtQueryProcessor(getDefaultSearchOptimisedFieldItems());
+        this.queryProcessor = uniProtKBQueryProcessor;
         this.facetTupleStreamConverter = new FacetTupleStreamConverter(uniprotKBFacetConfig);
         this.facetTupleStreamTemplate = facetTupleStreamTemplate;
     }
@@ -285,9 +285,5 @@ public class UniProtEntryService
                         && Utils.notNullNotEmpty(accessionsRequest.getFacetList())
                         && !accessionsRequest.isDownload())
                 || Utils.notNullNotEmpty(accessionsRequest.getFacetFilter());
-    }
-
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        return Collections.singletonList(getIdField());
     }
 }

--- a/uniref-rest/src/main/java/org/uniprot/api/uniref/service/UniRefLightSearchService.java
+++ b/uniref-rest/src/main/java/org/uniprot/api/uniref/service/UniRefLightSearchService.java
@@ -1,7 +1,5 @@
 package org.uniprot.api.uniref.service;
 
-import static java.util.Arrays.asList;
-
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,7 +15,6 @@ import org.uniprot.api.rest.request.SearchRequest;
 import org.uniprot.api.rest.request.StreamRequest;
 import org.uniprot.api.rest.service.StoreStreamerSearchService;
 import org.uniprot.api.rest.service.query.QueryProcessor;
-import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
 import org.uniprot.api.uniref.repository.UniRefFacetConfig;
 import org.uniprot.api.uniref.repository.UniRefQueryRepository;
 import org.uniprot.api.uniref.request.UniRefSearchRequest;
@@ -40,6 +37,8 @@ public class UniRefLightSearchService
         extends StoreStreamerSearchService<UniRefDocument, UniRefEntryLight> {
 
     private static final int ID_LIMIT = 10;
+    public static final String UNIREF_ID = "id";
+    public static final String UNIREF_UPI = "upi";
     private final SearchFieldConfig searchFieldConfig;
     private final QueryProcessor queryProcessor;
 
@@ -50,7 +49,8 @@ public class UniRefLightSearchService
             UniRefSortClause uniRefSortClause,
             UniRefLightQueryResultConverter uniRefQueryResultConverter,
             StoreStreamer<UniRefEntryLight> storeStreamer,
-            SolrQueryConfig uniRefSolrQueryConf) {
+            SolrQueryConfig uniRefSolrQueryConf,
+            QueryProcessor uniRefQueryProcessor) {
         super(
                 repository,
                 uniRefQueryResultConverter,
@@ -60,7 +60,7 @@ public class UniRefLightSearchService
                 uniRefSolrQueryConf);
         this.searchFieldConfig =
                 SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.UNIREF);
-        this.queryProcessor = new UniProtQueryProcessor(getDefaultSearchOptimisedFieldItems());
+        this.queryProcessor = uniRefQueryProcessor;
     }
 
     @Override
@@ -111,18 +111,12 @@ public class UniRefLightSearchService
 
     @Override
     protected SearchFieldItem getIdField() {
-        return this.searchFieldConfig.getSearchFieldItemByName("id");
+        return this.searchFieldConfig.getSearchFieldItemByName(UNIREF_ID);
     }
 
     @Override
     protected QueryProcessor getQueryProcessor() {
         return queryProcessor;
-    }
-
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        return asList(
-                searchFieldConfig.getSearchFieldItemByName("id"),
-                searchFieldConfig.getSearchFieldItemByName("upi"));
     }
 
     private UniRefEntryLight cleanMemberId(UniRefEntryLight entry) {

--- a/uniref-rest/src/main/java/org/uniprot/api/uniref/service/UniRefLightSearchService.java
+++ b/uniref-rest/src/main/java/org/uniprot/api/uniref/service/UniRefLightSearchService.java
@@ -21,9 +21,7 @@ import org.uniprot.api.uniref.request.UniRefSearchRequest;
 import org.uniprot.api.uniref.request.UniRefStreamRequest;
 import org.uniprot.core.uniref.UniRefEntryLight;
 import org.uniprot.core.uniref.impl.UniRefEntryLightBuilder;
-import org.uniprot.store.config.UniProtDataType;
 import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
-import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
 import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 import org.uniprot.store.search.document.uniref.UniRefDocument;
 
@@ -50,7 +48,8 @@ public class UniRefLightSearchService
             UniRefLightQueryResultConverter uniRefQueryResultConverter,
             StoreStreamer<UniRefEntryLight> storeStreamer,
             SolrQueryConfig uniRefSolrQueryConf,
-            QueryProcessor uniRefQueryProcessor) {
+            QueryProcessor uniRefQueryProcessor,
+            SearchFieldConfig uniRefSearchFieldConfig) {
         super(
                 repository,
                 uniRefQueryResultConverter,
@@ -58,8 +57,7 @@ public class UniRefLightSearchService
                 facetConfig,
                 storeStreamer,
                 uniRefSolrQueryConf);
-        this.searchFieldConfig =
-                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.UNIREF);
+        this.searchFieldConfig = uniRefSearchFieldConfig;
         this.queryProcessor = uniRefQueryProcessor;
     }
 

--- a/uniref-rest/src/main/java/org/uniprot/api/uniref/service/UniRefSolrQueryConfig.java
+++ b/uniref-rest/src/main/java/org/uniprot/api/uniref/service/UniRefSolrQueryConfig.java
@@ -1,9 +1,22 @@
 package org.uniprot.api.uniref.service;
 
+import static java.util.Arrays.asList;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.uniprot.api.common.repository.search.SolrQueryConfig;
 import org.uniprot.api.common.repository.search.SolrQueryConfigFileReader;
+import org.uniprot.api.rest.service.query.QueryProcessor;
+import org.uniprot.api.rest.service.query.UniProtQueryProcessor;
+import org.uniprot.api.rest.validation.config.WhitelistFieldConfig;
+import org.uniprot.store.config.UniProtDataType;
+import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
+import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
+import org.uniprot.store.config.searchfield.model.SearchFieldItem;
 
 @Configuration
 public class UniRefSolrQueryConfig {
@@ -12,5 +25,24 @@ public class UniRefSolrQueryConfig {
     @Bean
     public SolrQueryConfig uniRefSolrQueryConf() {
         return new SolrQueryConfigFileReader(RESOURCE_LOCATION).getConfig();
+    }
+
+    @Bean
+    public QueryProcessor uniRefQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+        Map<String, String> uniRefWhiteListFields =
+                whiteListFieldConfig
+                        .getField()
+                        .getOrDefault(
+                                UniProtDataType.UNIREF.toString().toLowerCase(), new HashMap<>());
+        return new UniProtQueryProcessor(
+                getDefaultSearchOptimisedFieldItems(), uniRefWhiteListFields);
+    }
+
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
+        SearchFieldConfig searchFieldConfig =
+                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.UNIREF);
+        return asList(
+                searchFieldConfig.getSearchFieldItemByName(UniRefLightSearchService.UNIREF_ID),
+                searchFieldConfig.getSearchFieldItemByName(UniRefLightSearchService.UNIREF_UPI));
     }
 }

--- a/uniref-rest/src/main/java/org/uniprot/api/uniref/service/UniRefSolrQueryConfig.java
+++ b/uniref-rest/src/main/java/org/uniprot/api/uniref/service/UniRefSolrQueryConfig.java
@@ -28,21 +28,29 @@ public class UniRefSolrQueryConfig {
     }
 
     @Bean
-    public QueryProcessor uniRefQueryProcessor(WhitelistFieldConfig whiteListFieldConfig) {
+    public SearchFieldConfig uniRefSearchFieldConfig() {
+        return SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.UNIREF);
+    }
+
+    @Bean
+    public QueryProcessor uniRefQueryProcessor(
+            WhitelistFieldConfig whiteListFieldConfig, SearchFieldConfig uniRefSearchFieldConfig) {
         Map<String, String> uniRefWhiteListFields =
                 whiteListFieldConfig
                         .getField()
                         .getOrDefault(
                                 UniProtDataType.UNIREF.toString().toLowerCase(), new HashMap<>());
         return new UniProtQueryProcessor(
-                getDefaultSearchOptimisedFieldItems(), uniRefWhiteListFields);
+                getDefaultSearchOptimisedFieldItems(uniRefSearchFieldConfig),
+                uniRefWhiteListFields);
     }
 
-    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems() {
-        SearchFieldConfig searchFieldConfig =
-                SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.UNIREF);
+    private List<SearchFieldItem> getDefaultSearchOptimisedFieldItems(
+            SearchFieldConfig uniRefSearchFieldConfig) {
         return asList(
-                searchFieldConfig.getSearchFieldItemByName(UniRefLightSearchService.UNIREF_ID),
-                searchFieldConfig.getSearchFieldItemByName(UniRefLightSearchService.UNIREF_UPI));
+                uniRefSearchFieldConfig.getSearchFieldItemByName(
+                        UniRefLightSearchService.UNIREF_ID),
+                uniRefSearchFieldConfig.getSearchFieldItemByName(
+                        UniRefLightSearchService.UNIREF_UPI));
     }
 }


### PR DESCRIPTION
 In Our UniProtKB database we have some ids that has the following format <prefix><colon><postfix>,
 for example (HGNC:3689).
 These Ids, are processed wrongly by solr query parser, basically, it identify HGNC as a field name, causing
 an error in the request, because we do not have a defined field named HGNC in our solr schema.

 In order to sort out this problem, we created this property file with a list of trouble ids that will need to be
 whitelisted in our field validation and handled specially in our UniProtFieldQueryNodeProcessor.