### PR TITLE
add seedId to UniRefEntry

### DIFF
--- a/uniref-rest/src/main/java/org/uniprot/api/uniref/repository/store/UniRefEntryStoreRepository.java
+++ b/uniref-rest/src/main/java/org/uniprot/api/uniref/repository/store/UniRefEntryStoreRepository.java
@@ -98,6 +98,7 @@ public class UniRefEntryStoreRepository {
             builder.commonTaxonId(entryLight.getCommonTaxonId());
             builder.commonTaxon(entryLight.getCommonTaxon());
             builder.goTermsSet(entryLight.getGoTerms());
+            builder.seedId(getSeedId(entryLight));
         }
         // build members
         BatchStoreIterable<RepresentativeMember> batchIterable =
@@ -121,7 +122,7 @@ public class UniRefEntryStoreRepository {
             RepresentativeMember storedMember,
             UniRefEntryBuilder builder,
             UniRefEntryLight entryLight) {
-        if (storedMember.getMemberId().equalsIgnoreCase(entryLight.getRepresentativeId())) {
+        if (storedMember.getMemberId().equalsIgnoreCase(getRepresentativeMemberId(entryLight))) {
             RepresentativeMemberBuilder repBuilder = RepresentativeMemberBuilder.from(storedMember);
             cleanMemberFields(repBuilder, entryLight, storedMember.getMemberId());
             builder.representativeMember(repBuilder.build());
@@ -149,7 +150,7 @@ public class UniRefEntryStoreRepository {
             default:
                 break;
         }
-        if (memberId.equalsIgnoreCase(entryLight.getSeedId())) {
+        if (memberId.equalsIgnoreCase(getSeedMemberId(entryLight))) {
             builder.isSeed(true);
         }
     }
@@ -171,5 +172,18 @@ public class UniRefEntryStoreRepository {
         int offset = page.getOffset().intValue();
         int nextOffset = CursorPage.getNextOffset(page);
         return members.subList(offset, nextOffset);
+    }
+
+    private String getSeedId(UniRefEntryLight entryLight) {
+        String[] splittedSeed = entryLight.getSeedId().split(",");
+        return splittedSeed[splittedSeed.length - 1];
+    }
+
+    private String getSeedMemberId(UniRefEntryLight entryLight) {
+        return entryLight.getSeedId().split(",")[0];
+    }
+
+    private String getRepresentativeMemberId(UniRefEntryLight entryLight) {
+        return entryLight.getRepresentativeId().split(",")[0];
     }
 }

--- a/uniref-rest/src/test/java/org/uniprot/api/uniref/controller/UniRefControllerITUtils.java
+++ b/uniref-rest/src/test/java/org/uniprot/api/uniref/controller/UniRefControllerITUtils.java
@@ -59,6 +59,7 @@ class UniRefControllerITUtils {
                 .entryType(type)
                 .commonTaxonId(9606L)
                 .commonTaxon("Homo sapiens")
+                .seedId(getName(ACC_2_PREF, i))
                 .representativeMember(createReprestativeMember(i))
                 .membersAdd(createMember(i))
                 .goTermsAdd(

--- a/uniref-rest/src/test/java/org/uniprot/api/uniref/controller/UniRefGetIdControllerIT.java
+++ b/uniref-rest/src/test/java/org/uniprot/api/uniref/controller/UniRefGetIdControllerIT.java
@@ -159,6 +159,7 @@ class UniRefGetIdControllerIT extends AbstractGetByIdControllerIT {
                 .andExpect(jsonPath("$.entryType", is("UniRef50")))
                 .andExpect(jsonPath("$.commonTaxonId", is(9606)))
                 .andExpect(jsonPath("$.commonTaxon", is("Homo sapiens")))
+                .andExpect(jsonPath("$.seedId", is("P12301")))
                 .andExpect(jsonPath("$.goTerms.size()", is(3)))
                 .andExpect(jsonPath("$.representativeMember.memberIdType", is("UniProtKB ID")))
                 .andExpect(jsonPath("$.representativeMember.memberId", is("P12301_HUMAN")))

--- a/uniref-rest/src/test/java/org/uniprot/api/uniref/controller/UniRefLightSearchControllerIT.java
+++ b/uniref-rest/src/test/java/org/uniprot/api/uniref/controller/UniRefLightSearchControllerIT.java
@@ -136,6 +136,8 @@ class UniRefLightSearchControllerIT extends AbstractSearchWithFacetControllerIT 
                 .andExpect(status().is(HttpStatus.OK.value()))
                 .andExpect(header().string(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$.results[*].id", contains("UniRef50_P03901")))
+                .andExpect(jsonPath("$.results[*].representativeId", contains("P12301")))
+                .andExpect(jsonPath("$.results[*].seedId", contains("P12301")))
                 .andExpect(jsonPath("$.results[*].members.size()", contains(10)))
                 .andExpect(
                         jsonPath(
@@ -458,7 +460,14 @@ class UniRefLightSearchControllerIT extends AbstractSearchWithFacetControllerIT 
                                     .contentType(UniProtMediaType.FASTA_MEDIA_TYPE)
                                     .resultMatcher(
                                             content()
-                                                    .contentType(UniProtMediaType.FASTA_MEDIA_TYPE))
+                                                    .string(
+                                                            containsString(
+                                                                    ">UniRef50_P03911 MoeK5 11 n=2 Tax=Homo sapiens TaxID=9606 RepID=P12311_HUMAN")))
+                                    .resultMatcher(
+                                            content()
+                                                    .string(
+                                                            containsString(
+                                                                    ">UniRef50_P03911 MoeK5 11 n=2 Tax=Homo sapiens TaxID=9606 RepID=P12311_HUMAN")))
                                     .build())
                     .build();
         }

--- a/uniref-rest/src/test/java/org/uniprot/api/uniref/controller/UniRefLightStreamControllerIT.java
+++ b/uniref-rest/src/test/java/org/uniprot/api/uniref/controller/UniRefLightStreamControllerIT.java
@@ -124,7 +124,9 @@ class UniRefLightStreamControllerIT extends AbstractStreamControllerIT {
                                         "UniRef100_P03903",
                                         "UniRef50_P03904",
                                         "UniRef90_P03904",
-                                        "UniRef100_P03904")));
+                                        "UniRef100_P03904")))
+                .andExpect(jsonPath("$.results[0].representativeId", is("P12301")))
+                .andExpect(jsonPath("$.results[0].representativeId", is("P12301")));
     }
 
     @Test


### PR DESCRIPTION
- Add seedId to UniRefEntry. The seedId is storing UniprotKB accession or UniParcId if the member type is UniParc.
- Update seedId and ReferenceId values in UniRefEntryLight to accession, to make it consistent with seedId in UniRefEntry.

The idea is that we display accession for seedId in both entities (UniRefEntry and UniRefEntryLight) 