### PR TITLE
update UniRef

### DIFF
--- a/uniref-rest/src/main/java/org/uniprot/api/uniref/repository/store/UniRefEntryStoreRepository.java
+++ b/uniref-rest/src/main/java/org/uniprot/api/uniref/repository/store/UniRefEntryStoreRepository.java
@@ -95,8 +95,10 @@ public class UniRefEntryStoreRepository {
             builder.entryType(entryLight.getEntryType());
             builder.updated(entryLight.getUpdated());
             builder.memberCount(entryLight.getMemberCount());
-            builder.commonTaxonId(entryLight.getCommonTaxonId());
-            builder.commonTaxon(entryLight.getCommonTaxon());
+            if (entryLight.getCommonTaxon() != null) {
+                builder.commonTaxonId(entryLight.getCommonTaxon().getTaxonId());
+                builder.commonTaxon(entryLight.getCommonTaxon().getScientificName());
+            }
             builder.goTermsSet(entryLight.getGoTerms());
             builder.seedId(getSeedId(entryLight));
         }

--- a/uniref-rest/src/main/java/org/uniprot/api/uniref/service/UniRefLightSearchService.java
+++ b/uniref-rest/src/main/java/org/uniprot/api/uniref/service/UniRefLightSearchService.java
@@ -19,6 +19,7 @@ import org.uniprot.api.uniref.repository.UniRefFacetConfig;
 import org.uniprot.api.uniref.repository.UniRefQueryRepository;
 import org.uniprot.api.uniref.request.UniRefSearchRequest;
 import org.uniprot.api.uniref.request.UniRefStreamRequest;
+import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.uniref.UniRefEntryLight;
 import org.uniprot.core.uniref.impl.UniRefEntryLightBuilder;
 import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
@@ -137,15 +138,8 @@ public class UniRefLightSearchService
         members = removeMemberTypeFromMemberId(members);
         builder.membersSet(members);
 
-        if (entry.getOrganismIds().size() > ID_LIMIT) {
-            LinkedHashSet<Long> organismIds =
-                    entry.getOrganismIds().stream()
-                            .limit(ID_LIMIT)
-                            .collect(Collectors.toCollection(LinkedHashSet::new));
-            builder.organismIdsSet(organismIds);
-        }
         if (entry.getOrganisms().size() > ID_LIMIT) {
-            LinkedHashSet<String> organisms =
+            LinkedHashSet<Organism> organisms =
                     entry.getOrganisms().stream()
                             .limit(ID_LIMIT)
                             .collect(Collectors.toCollection(LinkedHashSet::new));

--- a/uniref-rest/src/test/java/org/uniprot/api/uniref/controller/UniRefLightSearchControllerIT.java
+++ b/uniref-rest/src/test/java/org/uniprot/api/uniref/controller/UniRefLightSearchControllerIT.java
@@ -148,9 +148,9 @@ class UniRefLightSearchControllerIT extends AbstractSearchWithFacetControllerIT 
                 .andExpect(jsonPath("$.results[*].organisms.size()", contains(10)))
                 .andExpect(
                         jsonPath(
-                                "$.results[*].organisms[*]",
+                                "$.results[*].organisms[*].scientificName",
                                 contains(
-                                        "Homo sapiens (Representative)",
+                                        "Homo sapiens",
                                         "Homo sapiens 1",
                                         "Homo sapiens 2",
                                         "Homo sapiens 3",
@@ -160,10 +160,9 @@ class UniRefLightSearchControllerIT extends AbstractSearchWithFacetControllerIT 
                                         "Homo sapiens 7",
                                         "Homo sapiens 8",
                                         "Homo sapiens 9")))
-                .andExpect(jsonPath("$.results[*].organismIds.size()", contains(10)))
                 .andExpect(
                         jsonPath(
-                                "$.results[*].organismIds[*]",
+                                "$.results[*].organisms[*].taxonId",
                                 contains(
                                         9600, 9607, 9608, 9609, 9610, 9611, 9612, 9613, 9614,
                                         9615)))
@@ -191,7 +190,6 @@ class UniRefLightSearchControllerIT extends AbstractSearchWithFacetControllerIT 
                 .andExpect(jsonPath("$.results[*].id", contains("UniRef50_P03901")))
                 .andExpect(jsonPath("$.results[*].members.size()", contains(12)))
                 .andExpect(jsonPath("$.results[*].organisms.size()", contains(12)))
-                .andExpect(jsonPath("$.results[*].organismIds.size()", contains(12)))
                 .andExpect(jsonPath("$.results[*].memberCount", contains(12)))
                 .andExpect(jsonPath("$.results[*].organismCount", contains(12)));
     }
@@ -337,7 +335,7 @@ class UniRefLightSearchControllerIT extends AbstractSearchWithFacetControllerIT 
         protected SearchParameter searchQueryWithInvalidTypeQueryReturnBadRequestParameter() {
             return SearchParameter.builder()
                     .queryParam("query", Collections.singletonList("taxonomy_name:[1 TO 10]"))
-                    .resultMatcher(jsonPath("$.url", not(isEmptyOrNullString())))
+                    .resultMatcher(jsonPath("$.url", not(emptyOrNullString())))
                     .resultMatcher(
                             jsonPath(
                                     "$.messages.*",
@@ -354,7 +352,7 @@ class UniRefLightSearchControllerIT extends AbstractSearchWithFacetControllerIT 
                             Collections.singletonList(
                                     "id:INVALID OR taxonomy_id:INVALID "
                                             + "OR length:INVALID OR count:INVALID  OR upi:INVALID"))
-                    .resultMatcher(jsonPath("$.url", not(isEmptyOrNullString())))
+                    .resultMatcher(jsonPath("$.url", not(emptyOrNullString())))
                     .resultMatcher(
                             jsonPath(
                                     "$.messages.*",
@@ -479,7 +477,7 @@ class UniRefLightSearchControllerIT extends AbstractSearchWithFacetControllerIT 
                     .contentTypeParam(
                             ContentTypeParam.builder()
                                     .contentType(MediaType.APPLICATION_JSON)
-                                    .resultMatcher(jsonPath("$.url", not(isEmptyOrNullString())))
+                                    .resultMatcher(jsonPath("$.url", not(emptyOrNullString())))
                                     .resultMatcher(
                                             jsonPath(
                                                     "$.messages.*",
@@ -489,17 +487,17 @@ class UniRefLightSearchControllerIT extends AbstractSearchWithFacetControllerIT 
                     .contentTypeParam(
                             ContentTypeParam.builder()
                                     .contentType(UniProtMediaType.LIST_MEDIA_TYPE)
-                                    .resultMatcher(content().string(isEmptyString()))
+                                    .resultMatcher(content().string(emptyString()))
                                     .build())
                     .contentTypeParam(
                             ContentTypeParam.builder()
                                     .contentType(UniProtMediaType.TSV_MEDIA_TYPE)
-                                    .resultMatcher(content().string(isEmptyString()))
+                                    .resultMatcher(content().string(emptyString()))
                                     .build())
                     .contentTypeParam(
                             ContentTypeParam.builder()
                                     .contentType(UniProtMediaType.XLS_MEDIA_TYPE)
-                                    .resultMatcher(content().string(isEmptyString()))
+                                    .resultMatcher(content().string(emptyString()))
                                     .build())
                     .contentTypeParam(
                             ContentTypeParam.builder()

--- a/uniref-rest/src/test/java/org/uniprot/api/uniref/controller/UniRefLightStreamControllerIT.java
+++ b/uniref-rest/src/test/java/org/uniprot/api/uniref/controller/UniRefLightStreamControllerIT.java
@@ -246,8 +246,8 @@ class UniRefLightStreamControllerIT extends AbstractStreamControllerIT {
                                 "$.results.*.id",
                                 containsInAnyOrder("UniRef100_P03901", "UniRef100_P03902")))
                 .andExpect(jsonPath("$.results.*.sequenceLength", contains(66, 66)))
-                .andExpect(jsonPath("$.results.*.organismIds", hasItem(hasItem(9600))))
-                .andExpect(jsonPath("$.results.*.organisms").doesNotExist())
+                .andExpect(jsonPath("$.results.*.organisms[0].taxonId", hasItem(is(9600))))
+                .andExpect(jsonPath("$.results.*.organisms.*.scientificName").doesNotExist())
                 .andExpect(jsonPath("$.results.*.name").doesNotExist());
         ;
     }

--- a/uniref-rest/src/test/java/org/uniprot/api/uniref/repository/store/UniRefEntryStoreRepositoryTest.java
+++ b/uniref-rest/src/test/java/org/uniprot/api/uniref/repository/store/UniRefEntryStoreRepositoryTest.java
@@ -20,6 +20,8 @@ import org.uniprot.core.cv.go.impl.GeneOntologyEntryBuilder;
 import org.uniprot.core.impl.SequenceBuilder;
 import org.uniprot.core.uniparc.impl.UniParcIdBuilder;
 import org.uniprot.core.uniprotkb.impl.UniProtKBAccessionBuilder;
+import org.uniprot.core.uniprotkb.taxonomy.Organism;
+import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
 import org.uniprot.core.uniref.*;
 import org.uniprot.core.uniref.impl.RepresentativeMemberBuilder;
 import org.uniprot.core.uniref.impl.UniRefEntryLightBuilder;
@@ -294,6 +296,8 @@ class UniRefEntryStoreRepositoryTest {
     }
 
     private void createLightEntries(UniRefLightStoreClient lightStoreClient) {
+        Organism commonOrganism =
+                new OrganismBuilder().taxonId(10L).scientificName("common taxon value").build();
         UniRefEntryLightBuilder builderOk =
                 new UniRefEntryLightBuilder()
                         .id(UNIREF_ID_OK)
@@ -305,8 +309,7 @@ class UniRefEntryStoreRepositoryTest {
                                         .aspect(GoAspect.COMPONENT)
                                         .id("1")
                                         .build())
-                        .commonTaxonId(10L)
-                        .commonTaxon("common taxon value")
+                        .commonTaxon(commonOrganism)
                         .memberIdTypesAdd(UniRefMemberIdType.UNIPROTKB)
                         .representativeId(REPRESENTATIVE_ID)
                         .membersAdd(REPRESENTATIVE_ID)


### PR DESCRIPTION
- add cluster solr search field and enable it in the search
- UniRefEntryLight  model change: commonOrganism id and name moved to Organism 

- add retry logic to datastore and solr index to try to avoid 11PM errors