### PR TITLE
uniparc accession filtering

### DIFF
--- a/uniparc-rest/src/test/java/org/uniprot/api/uniparc/controller/UniParcControllerITUtils.java
+++ b/uniparc-rest/src/test/java/org/uniprot/api/uniparc/controller/UniParcControllerITUtils.java
@@ -10,17 +10,8 @@ import org.uniprot.core.Location;
 import org.uniprot.core.Property;
 import org.uniprot.core.Sequence;
 import org.uniprot.core.impl.SequenceBuilder;
-import org.uniprot.core.uniparc.InterProGroup;
-import org.uniprot.core.uniparc.SequenceFeature;
-import org.uniprot.core.uniparc.SignatureDbType;
-import org.uniprot.core.uniparc.UniParcCrossReference;
-import org.uniprot.core.uniparc.UniParcDatabase;
-import org.uniprot.core.uniparc.UniParcEntry;
-import org.uniprot.core.uniparc.impl.InterProGroupBuilder;
-import org.uniprot.core.uniparc.impl.SequenceFeatureBuilder;
-import org.uniprot.core.uniparc.impl.UniParcCrossReferenceBuilder;
-import org.uniprot.core.uniparc.impl.UniParcEntryBuilder;
-import org.uniprot.core.uniparc.impl.UniParcIdBuilder;
+import org.uniprot.core.uniparc.*;
+import org.uniprot.core.uniparc.impl.*;
 import org.uniprot.core.uniprotkb.taxonomy.Taxonomy;
 import org.uniprot.core.uniprotkb.taxonomy.impl.TaxonomyBuilder;
 
@@ -84,9 +75,7 @@ public class UniParcControllerITUtils {
                 new Property(UniParcCrossReference.PROPERTY_GENE_NAME, getName("geneName", i)));
         properties.add(
                 new Property(UniParcCrossReference.PROPERTY_PROTEOME_ID, getName("UP1234567", i)));
-        properties.add(
-                new Property(
-                        UniParcCrossReference.PROPERTY_UNIPROT_KB_ACCESSION, getName("P321", i)));
+        properties.add(new Property(UniParcCrossReference.PROPERTY_CHAIN, "chain"));
         UniParcCrossReference xref =
                 new UniParcCrossReferenceBuilder()
                         .versionI(3)

--- a/uniparc-rest/src/test/java/org/uniprot/api/uniparc/service/filter/UniParcCrossReferenceTaxonomyFilterTest.java
+++ b/uniparc-rest/src/test/java/org/uniprot/api/uniparc/service/filter/UniParcCrossReferenceTaxonomyFilterTest.java
@@ -41,7 +41,7 @@ class UniParcCrossReferenceTaxonomyFilterTest {
     void testFilterByTaxonomyIds() {
         verifyUniParcEntry(uniParcEntry);
         assertEquals(2, this.uniParcEntry.getTaxonomies().size());
-        List<String> taxonFilter = Arrays.asList("9606");
+        List<String> taxonFilter = Collections.singletonList("9606");
         // filter by db
         UniParcEntry filteredEntry = uniParcTaxonomyFilter.apply(this.uniParcEntry, taxonFilter);
         // everything should be same except xrefs

--- a/uniparc-rest/src/test/java/org/uniprot/api/uniparc/service/filter/UniParcTaxonomyFilterTest.java
+++ b/uniparc-rest/src/test/java/org/uniprot/api/uniparc/service/filter/UniParcTaxonomyFilterTest.java
@@ -2,6 +2,7 @@ package org.uniprot.api.uniparc.service.filter;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
@@ -40,7 +41,7 @@ class UniParcTaxonomyFilterTest {
     void testFilterByTaxonomyIds() {
         verifyUniParcEntry(uniParcEntry);
         Assertions.assertEquals(2, this.uniParcEntry.getTaxonomies().size());
-        List<String> taxonFilter = Arrays.asList("9606");
+        List<String> taxonFilter = Collections.singletonList("9606");
         // filter by db
         UniParcEntry filteredEntry = uniParcTaxonomyFilter.apply(this.uniParcEntry, taxonFilter);
         // everything should be same except xrefs
@@ -79,7 +80,7 @@ class UniParcTaxonomyFilterTest {
         verifyUniParcEntry(uniParcEntry);
         List<Taxonomy> taxonomies = uniParcEntry.getTaxonomies();
         Assertions.assertEquals(2, this.uniParcEntry.getUniParcCrossReferences().size());
-        List<String> taxonFilter = Arrays.asList("0");
+        List<String> taxonFilter = Collections.singletonList("0");
         // filter by taxon
         UniParcEntry filteredEntry = uniParcTaxonomyFilter.apply(this.uniParcEntry, taxonFilter);
         // everything should be same but no taxon
@@ -96,7 +97,7 @@ class UniParcTaxonomyFilterTest {
         UniParcEntryBuilder entryBuilder = UniParcEntryBuilder.from(uniParcEntry);
         entryBuilder.taxonomiesSet(null);
         UniParcEntry entryWithoutXref = entryBuilder.build();
-        List<String> filter = Arrays.asList("9606");
+        List<String> filter = Collections.singletonList("9606");
         // filter by taxon
         UniParcEntry filteredEntry = uniParcTaxonomyFilter.apply(entryWithoutXref, filter);
         Assertions.assertEquals(entryWithoutXref, filteredEntry);


### PR DESCRIPTION
changing test that mocked "UniProtKB_accession" property in uniparc json xrefs, which doesn't seem to exist.

done because front-end found that accession filtering on uniparc responses gave empty results.