### PR TITLE
improve FacetStream to allow descending order values

### DIFF
--- a/common-rest/src/main/java/org/uniprot/api/common/repository/solrstream/FacetTupleStreamTemplate.java
+++ b/common-rest/src/main/java/org/uniprot/api/common/repository/solrstream/FacetTupleStreamTemplate.java
@@ -13,6 +13,7 @@ import org.apache.solr.client.solrj.io.stream.StreamContext;
 import org.apache.solr.client.solrj.io.stream.TupleStream;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 import org.apache.solr.client.solrj.io.stream.expr.StreamFactory;
+import org.uniprot.api.common.repository.search.facet.FacetConfig;
 
 /**
  * This class is responsible for simplifying the creation of {@link TupleStream} instances for facet
@@ -34,7 +35,7 @@ public class FacetTupleStreamTemplate extends AbstractTupleStreamTemplate {
     private final String collection;
     private final HttpClient httpClient;
 
-    public TupleStream create(SolrStreamFacetRequest request) {
+    public TupleStream create(SolrStreamFacetRequest request, FacetConfig facetConfig) {
         try {
             List<StreamExpression> expressions = new ArrayList<>();
             // add search function if needed
@@ -49,7 +50,7 @@ public class FacetTupleStreamTemplate extends AbstractTupleStreamTemplate {
                             .map(
                                     facet ->
                                             new FacetStreamExpression(
-                                                    this.collection, facet, request))
+                                                    this.collection, facet, request, facetConfig))
                             .collect(Collectors.toList());
 
             expressions.addAll(facetExpressions);

--- a/common-rest/src/main/java/org/uniprot/api/rest/service/BasicSearchService.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/service/BasicSearchService.java
@@ -36,7 +36,7 @@ public abstract class BasicSearchService<D extends Document, R> {
     private final Function<D, R> entryConverter;
     protected final AbstractSolrSortClause solrSortClause;
     protected final SolrQueryConfig queryBoosts;
-    private final FacetConfig facetConfig;
+    protected final FacetConfig facetConfig;
 
     // If this property is not set then it is set to empty and later it is set to
     // DEFAULT_SOLR_BATCH_SIZE

--- a/common-rest/src/main/java/org/uniprot/api/rest/service/StoreStreamerSearchService.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/service/StoreStreamerSearchService.java
@@ -123,7 +123,7 @@ public abstract class StoreStreamerSearchService<D extends Document, R>
 
     private SolrStreamFacetResponse searchBySolrStream(IdsSearchRequest idsRequest) {
         SolrStreamFacetRequest solrStreamRequest = createSolrStreamRequest(idsRequest);
-        TupleStream tupleStream = this.tupleStreamTemplate.create(solrStreamRequest);
+        TupleStream tupleStream = this.tupleStreamTemplate.create(solrStreamRequest, facetConfig);
         return this.tupleStreamConverter.convert(tupleStream);
     }
 

--- a/common-rest/src/test/java/org/uniprot/api/common/repository/solrstream/FacetStreamExpressionTest.java
+++ b/common-rest/src/test/java/org/uniprot/api/common/repository/solrstream/FacetStreamExpressionTest.java
@@ -11,8 +11,10 @@ import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionValue;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.uniprot.api.common.repository.search.facet.FacetConfig;
+import org.uniprot.api.common.repository.search.facet.FakeFacetConfig;
 
-public class FacetStreamExpressionTest {
+class FacetStreamExpressionTest {
 
     @Test
     void testCreate() {
@@ -20,14 +22,15 @@ public class FacetStreamExpressionTest {
                 SolrStreamFacetRequest.builder();
         String collection = "sample collection";
         String query = "q:*:*";
-        String buckets = "facet";
-        String metrics = "count(facet)";
-        String bucketSorts = "count(facet)";
+        String buckets = "reviewed";
+        String metrics = "count(reviewed)";
+        String bucketSorts = "count(reviewed)";
         int bucketSizeLimit = 10;
         builder.query(query);
         builder.metrics(metrics).bucketSorts(bucketSorts).bucketSizeLimit(bucketSizeLimit);
+        FacetConfig facetConfig = new FakeFacetConfig();
         FacetStreamExpression facetExpression =
-                new FacetStreamExpression(collection, buckets, builder.build());
+                new FacetStreamExpression(collection, buckets, builder.build(), facetConfig);
         Assertions.assertNotNull(facetExpression);
         Assertions.assertEquals("facet", facetExpression.getFunctionName());
         Assertions.assertEquals(6, facetExpression.getParameters().size());
@@ -71,10 +74,13 @@ public class FacetStreamExpressionTest {
         int bucketSizeLimit = -1;
         builder.query(query);
         builder.metrics(metrics).bucketSorts(bucketSorts).bucketSizeLimit(bucketSizeLimit);
+        FacetConfig facetConfig = new FakeFacetConfig();
         IllegalArgumentException exception =
                 Assertions.assertThrows(
                         IllegalArgumentException.class,
-                        () -> new FacetStreamExpression(collection, buckets, builder.build()));
+                        () ->
+                                new FacetStreamExpression(
+                                        collection, buckets, builder.build(), facetConfig));
         Assertions.assertEquals(
                 "bucketSizeLimit should be a positive integer", exception.getMessage());
     }
@@ -84,10 +90,13 @@ public class FacetStreamExpressionTest {
         SolrStreamFacetRequest.SolrStreamFacetRequestBuilder builder =
                 SolrStreamFacetRequest.builder();
         String collection = "sample collection";
+        FacetConfig facetConfig = new FakeFacetConfig();
         IllegalArgumentException exception =
                 Assertions.assertThrows(
                         IllegalArgumentException.class,
-                        () -> new FacetStreamExpression(collection, "buckets", builder.build()));
+                        () ->
+                                new FacetStreamExpression(
+                                        collection, "buckets", builder.build(), facetConfig));
         Assertions.assertEquals("query is a mandatory param", exception.getMessage());
     }
 
@@ -95,10 +104,13 @@ public class FacetStreamExpressionTest {
     void testCreateFailureWithoutCollection() {
         SolrStreamFacetRequest.SolrStreamFacetRequestBuilder builder =
                 SolrStreamFacetRequest.builder();
+        FacetConfig facetConfig = new FakeFacetConfig();
         IllegalArgumentException exception =
                 Assertions.assertThrows(
                         IllegalArgumentException.class,
-                        () -> new FacetStreamExpression(null, "buckets", builder.build()));
+                        () ->
+                                new FacetStreamExpression(
+                                        null, "buckets", builder.build(), facetConfig));
         Assertions.assertEquals("collection is a mandatory param", exception.getMessage());
     }
 
@@ -108,16 +120,19 @@ public class FacetStreamExpressionTest {
                 SolrStreamFacetRequest.builder();
         String collection = "sample collection";
         String query = "q:*:*";
-        String buckets = "facet";
-        String metrics = "median(facet)";
-        String bucketSorts = "count(facet)";
+        String buckets = "reviewed";
+        String metrics = "median(reviewed)";
+        String bucketSorts = "count(reviewed)";
         int bucketSizeLimit = 1;
         builder.query(query);
         builder.metrics(metrics).bucketSorts(bucketSorts).bucketSizeLimit(bucketSizeLimit);
+        FacetConfig facetConfig = new FakeFacetConfig();
         IllegalArgumentException exception =
                 Assertions.assertThrows(
                         IllegalArgumentException.class,
-                        () -> new FacetStreamExpression(collection, buckets, builder.build()));
-        Assertions.assertEquals("Unknown function median(facet)", exception.getMessage());
+                        () ->
+                                new FacetStreamExpression(
+                                        collection, buckets, builder.build(), facetConfig));
+        Assertions.assertEquals("Unknown function median(reviewed)", exception.getMessage());
     }
 }

--- a/common-rest/src/test/java/org/uniprot/api/common/repository/solrstream/FacetTupleStreamTemplateTest.java
+++ b/common-rest/src/test/java/org/uniprot/api/common/repository/solrstream/FacetTupleStreamTemplateTest.java
@@ -12,6 +12,8 @@ import org.apache.solr.client.solrj.io.stream.TupleStream;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.uniprot.api.common.repository.search.facet.FacetConfig;
+import org.uniprot.api.common.repository.search.facet.FakeFacetConfig;
 import org.uniprot.store.search.SolrCollection;
 
 /** @author sahmad */
@@ -37,12 +39,13 @@ class FacetTupleStreamTemplateTest {
         SolrStreamFacetRequest.SolrStreamFacetRequestBuilder builder =
                 SolrStreamFacetRequest.builder();
         String query = "accession_id:(P12345 OR Q12345)";
-        String facet1 = "sample_facet1";
-        String facet2 = "sample_facet2";
-        String facet3 = "sample_facet3";
+        String facet1 = "reviewed";
+        String facet2 = "annotation";
+        String facet3 = "fragment";
         List<String> facets = Arrays.asList(facet1, facet2, facet3);
         SolrStreamFacetRequest request = builder.query(query).facets(facets).build();
-        TupleStream tupleStream = tupleStreamTemplate.create(request);
+        FacetConfig facetConfig = new FakeFacetConfig();
+        TupleStream tupleStream = tupleStreamTemplate.create(request, facetConfig);
         assertThat(tupleStream, Matchers.is(Matchers.notNullValue()));
         assertThat(tupleStream.children(), Matchers.is(Matchers.iterableWithSize(3)));
         tupleStream

--- a/common-rest/src/test/java/org/uniprot/api/common/repository/solrstream/ListStreamExpressionTest.java
+++ b/common-rest/src/test/java/org/uniprot/api/common/repository/solrstream/ListStreamExpressionTest.java
@@ -7,8 +7,10 @@ import java.util.concurrent.ThreadLocalRandom;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.uniprot.api.common.repository.search.facet.FacetConfig;
+import org.uniprot.api.common.repository.search.facet.FakeFacetConfig;
 
-public class ListStreamExpressionTest {
+class ListStreamExpressionTest {
 
     @Test
     void testCreateList() {
@@ -26,14 +28,15 @@ public class ListStreamExpressionTest {
                 SolrStreamFacetRequest.builder();
         String collection = "sample collection";
         String query = "q:*:*";
-        String buckets = "facet";
-        String metrics = "count(facet)";
-        String bucketSorts = "count(facet)";
+        String buckets = "reviewed";
+        String metrics = "count(reviewed)";
+        String bucketSorts = "count(reviewed)";
         int bucketSizeLimit = ThreadLocalRandom.current().nextInt(10, Integer.MAX_VALUE);
+        FacetConfig facetConfig = new FakeFacetConfig();
         builder.query(query)
                 .metrics(metrics)
                 .bucketSorts(bucketSorts)
                 .bucketSizeLimit(bucketSizeLimit);
-        return new FacetStreamExpression(collection, buckets, builder.build());
+        return new FacetStreamExpression(collection, buckets, builder.build(), facetConfig);
     }
 }

--- a/idmapping-rest/src/main/java/org/uniprot/api/idmapping/service/BasicIdService.java
+++ b/idmapping-rest/src/main/java/org/uniprot/api/idmapping/service/BasicIdService.java
@@ -45,6 +45,7 @@ public abstract class BasicIdService<T, U> {
     private final FacetTupleStreamConverter facetTupleStreamConverter;
     private final RDFStreamer rdfStreamer;
     private final SolrQueryConfig queryConfig;
+    private final FacetConfig facetConfig;
 
     @Value("${search.default.page.size:#{null}}")
     private Integer defaultPageSize;
@@ -57,6 +58,7 @@ public abstract class BasicIdService<T, U> {
             SolrQueryConfig queryConfig) {
         this.storeStreamer = storeStreamer;
         this.tupleStream = tupleStream;
+        this.facetConfig = facetConfig;
         this.facetTupleStreamConverter =
                 new FacetTupleStreamConverter(getSolrIdField(), facetConfig);
         this.rdfStreamer = rdfStreamer;
@@ -159,7 +161,7 @@ public abstract class BasicIdService<T, U> {
     private SolrStreamFacetResponse searchBySolrStream(
             List<String> ids, SearchRequest searchRequest) {
         SolrStreamFacetRequest solrStreamRequest = createSolrStreamRequest(ids, searchRequest);
-        TupleStream facetTupleStream = this.tupleStream.create(solrStreamRequest);
+        TupleStream facetTupleStream = this.tupleStream.create(solrStreamRequest, facetConfig);
         return this.facetTupleStreamConverter.convert(facetTupleStream);
     }
 

--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBGetByAccessionsWithFacetFilterIT.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBGetByAccessionsWithFacetFilterIT.java
@@ -109,10 +109,13 @@ class UniProtKBGetByAccessionsWithFacetFilterIT extends AbstractStreamController
 
             if (i % 2 == 0) {
                 entryBuilder.proteinExistence(ProteinExistence.PROTEIN_LEVEL);
+                entryBuilder.annotationScore(2);
             } else if (i % 3 == 0) {
                 entryBuilder.proteinExistence(ProteinExistence.TRANSCRIPT_LEVEL);
+                entryBuilder.annotationScore(3);
             } else {
                 entryBuilder.proteinExistence(ProteinExistence.HOMOLOGY);
+                entryBuilder.annotationScore(4);
             }
 
             UniProtKBEntry uniProtKBEntry = entryBuilder.build();
@@ -256,6 +259,35 @@ class UniProtKBGetByAccessionsWithFacetFilterIT extends AbstractStreamController
                 .andExpect(jsonPath("$.facets[1].values[0].label", equalTo("Unreviewed (TrEMBL)")))
                 .andExpect(jsonPath("$.facets[1].values[0].value", equalTo("false")))
                 .andExpect(jsonPath("$.facets[1].values[0].count", equalTo(4)));
+    }
+
+    @Test
+    void getByAccessionsWithAnnotationWithDescendingValuesFacetSuccess() throws Exception {
+        String facets = "annotation_score";
+        // when
+        ResultActions response =
+                mockMvc.perform(
+                        get(accessionsByIdPath)
+                                .header(ACCEPT, MediaType.APPLICATION_JSON)
+                                .param(
+                                        "accessions",
+                                        "P00013,P00012,P00011,P00017,P00016,P00014,P00018,P00020,P00015")
+                                .param("facets", facets)
+                                .param("fields", "accession")
+                                .param("size", "10"));
+
+        // then
+        response.andDo(log())
+                .andExpect(status().is(HttpStatus.OK.value()))
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON_VALUE))
+                .andExpect(jsonPath("$.results.size()", is(9)))
+                .andExpect(jsonPath("$.facets.*.label", contains("Annotation Score")))
+                .andExpect(jsonPath("$.facets.*.name", contains(facets)))
+                .andExpect(
+                        jsonPath(
+                                "$.facets[0].values.*.value",
+                                contains("4", "3", "2")))
+                .andExpect(jsonPath("$.facets[0].values.*.count", contains(3, 1, 5)));
     }
 
     @Test


### PR DESCRIPTION
The use case is annotation_score facet. Order from 5 to 1 descending. The fix is already working for search facet. This code change it to add it to stream facet.