### PR TITLE
fix isOrganismDiffer attribute

### DIFF
--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBSearchControllerIT.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBSearchControllerIT.java
@@ -810,6 +810,10 @@ class UniProtKBSearchControllerIT extends AbstractSearchWithFacetControllerIT {
                 .andExpect(jsonPath("$.results.*.primaryAccession", contains("P21802")))
                 .andExpect(
                         jsonPath(
+                                "$.results.*.comments[0].interactions[0].organismDiffer",
+                                contains(true)))
+                .andExpect(
+                        jsonPath(
                                 "$.results.*.comments[0].interactions[0].interactantOne.uniProtKBAccession",
                                 contains("P21802")))
                 .andExpect(


### PR DESCRIPTION
organismDiffer does not appear when use fields
With Fields, does not appear: https://www.ebi.ac.uk/uniprot/beta/api/uniprotkb/search?fields=accession%2Ccc_interaction&query=%28interactor%3AP05067%29%20AND%20%28accession%3AP05067%29

{
"interactantOne": {
"uniProtKBAccession": "P05067",
"intActId": "EBI-77613"
},
"interactantTwo": {
"uniProtKBAccession": "Q9NY61",
"geneName": "AATF",
"intActId": "EBI-372428"
},
"numberOfExperiments": 3
},

Without fields: it appears: https://www.ebi.ac.uk/uniprot/beta/api/uniprotkb/search?query=%28interactor%3AP05067%29%20AND%20%28accession%3AP05067%29

{
"interactantOne": {
"uniProtKBAccession": "P05067",
"intActId": "EBI-77613"
},
"interactantTwo": {
"uniProtKBAccession": "Q9NY61",
"geneName": "AATF",
"intActId": "EBI-372428"
},
"numberOfExperiments": 3,
"organismDiffer": false
},