### PR TITLE
add config to accept long url by springboot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<argLine>-Xmx1024m -XX:MaxPermSize=256m
+					<argLine>-Xmx2304m -XX:MaxPermSize=2304m
 						-Dlogback.configurationFile=${project.basedir}/../logback-test.xml
 						${argLine}</argLine>
 					<includes>

--- a/uniparc-rest/src/main/resources/application.properties
+++ b/uniparc-rest/src/main/resources/application.properties
@@ -2,6 +2,7 @@
 spring.profiles.active=live
 server.port=8090
 server.servlet.context-path=/uniprot/api
+server.max-http-header-size=64KB
 
 spring.jackson.default-property-inclusion=non_null
 search.default.page.size=25

--- a/uniparc-rest/src/test/java/org/uniprot/api/uniparc/controller/UniParcGetByUpisIT.java
+++ b/uniparc-rest/src/test/java/org/uniprot/api/uniparc/controller/UniParcGetByUpisIT.java
@@ -238,7 +238,6 @@ class UniParcGetByUpisIT extends AbstractGetByIdsControllerIT {
     protected String[] getErrorMessages() {
         return new String[] {
             "UPI 'INVALID2' has invalid format. It should be a valid UniParc id.",
-            "Only '10' upis are allowed in each request.",
             "The 'download' parameter has invalid format. It should be a boolean true or false.",
             "Invalid fields parameter value 'invalid'",
             "UPI 'INVALID' has invalid format. It should be a valid UniParc id.",
@@ -266,6 +265,11 @@ class UniParcGetByUpisIT extends AbstractGetByIdsControllerIT {
     @Override
     protected String getUnmatchedFacetFilter() {
         return "organism_name:missing";
+    }
+
+    @Override
+    protected String[] getIdLengthErrorMessage() {
+        return new String[] {"Only '1000' upis are allowed in each request."};
     }
 
     private void saveEntries() throws Exception {

--- a/uniparc-rest/src/test/resources/application.properties
+++ b/uniparc-rest/src/test/resources/application.properties
@@ -65,5 +65,5 @@ streamer.rdf.MaxRetries=3
 streamer.rdf.retryDelayMillis=1000
 
 ####################### Get by unique id ######################
-ids.max.length=10
+ids.max.length=1000
 ids.max.download.length=10

--- a/uniprotkb-rest/src/main/resources/application.properties
+++ b/uniprotkb-rest/src/main/resources/application.properties
@@ -2,6 +2,7 @@
 spring.profiles.active=live
 server.port=8090
 server.servlet.context-path=/uniprot/api
+server.max-http-header-size=64KB
 search.default.page.size=25
 
 ############################### Service Information #######################################################

--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBGetByAccessionsIT.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBGetByAccessionsIT.java
@@ -272,7 +272,6 @@ class UniProtKBGetByAccessionsIT extends AbstractGetByIdsControllerIT {
     @Override
     protected String[] getErrorMessages() {
         return new String[] {
-            "Only '10' accessions are allowed in each request.",
             "Invalid fields parameter value 'invalid'",
             "Invalid fields parameter value 'invalid1'",
             "The 'download' parameter has invalid format. It should be a boolean true or false.",
@@ -317,5 +316,10 @@ class UniProtKBGetByAccessionsIT extends AbstractGetByIdsControllerIT {
     @Override
     protected FacetTupleStreamTemplate getFacetTupleStreamTemplate() {
         return facetTupleStreamTemplate;
+    }
+
+    @Override
+    protected String[] getIdLengthErrorMessage() {
+        return new String[] {"Only '1000' accessions are allowed in each request."};
     }
 }

--- a/uniprotkb-rest/src/test/resources/application.properties
+++ b/uniprotkb-rest/src/test/resources/application.properties
@@ -72,7 +72,7 @@ streamer.rdf.retryDelayMillis=1000
 solr.query.batchSize=10
 
 ################################## accessions ################################
-ids.max.length=10
+ids.max.length=1000
 ids.max.download.length=10
 voldemort.uniprot.host=
 

--- a/uniref-rest/src/main/resources/application.properties
+++ b/uniref-rest/src/main/resources/application.properties
@@ -2,6 +2,7 @@
 spring.profiles.active=live
 server.port=8090
 server.servlet.context-path=/uniprot/api
+server.max-http-header-size=64KB
 
 spring.jackson.default-property-inclusion=non_null
 search.default.page.size=25

--- a/uniref-rest/src/test/java/org/uniprot/api/uniref/controller/UniRefGetByIdsIT.java
+++ b/uniref-rest/src/test/java/org/uniprot/api/uniref/controller/UniRefGetByIdsIT.java
@@ -272,7 +272,6 @@ class UniRefGetByIdsIT extends AbstractGetByIdsControllerIT {
             "UniRef id 'INVALID2' has invalid format. It should be a valid UniRef id.",
             "Invalid fields parameter value 'invalid'",
             "UniRef id 'INVALID' has invalid format. It should be a valid UniRef id.",
-            "Only '10' UniRef ids are allowed in each request.",
             "The 'download' parameter has invalid format. It should be a boolean true or false."
         };
     }
@@ -297,5 +296,10 @@ class UniRefGetByIdsIT extends AbstractGetByIdsControllerIT {
     @Override
     protected String getUnmatchedFacetFilter() {
         return "identity:2";
+    }
+
+    @Override
+    protected String[] getIdLengthErrorMessage() {
+        return new String[] {"Only '1000' UniRef ids are allowed in each request."};
     }
 }

--- a/uniref-rest/src/test/resources/application.properties
+++ b/uniref-rest/src/test/resources/application.properties
@@ -1,5 +1,4 @@
 search.default.page.size=25
-
 spring.test.mockmvc.print=none
 spring.main.banner-mode=off
 streamer.uniref.searchBatchSize=5
@@ -34,5 +33,5 @@ streamer.rdf.MaxRetries=3
 streamer.rdf.retryDelayMillis=1000
 
 ####################### Get by unique id ######################
-ids.max.length=10
+ids.max.length=1000
 ids.max.download.length=10


### PR DESCRIPTION
Springboot server throws the below error for  long url
2021-11-03 17:51:58.008  INFO [http-nio-0.0.0.0-8090-exec-2] --- Error parsing HTTP request header
 Note: further occurrences of HTTP request parsing errors will be logged at DEBUG level.
java.lang.IllegalArgumentException: Request header is too large
        at org.apache.coyote.http11.Http11InputBuffer.fill(Http11InputBuffer.java:766)
        at org.apache.coyote.http11.Http11InputBuffer.parseRequestLine(Http11InputBuffer.java:452)
        at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:260)
        at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65)
        at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:868)
        at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1590)
        at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
        at java.base/java.lang.Thread.run(Thread.java:834)