### PR TITLE
Trm 27110 inactive entry redirect with file extension

### DIFF
--- a/common-rest/src/main/java/org/uniprot/api/rest/controller/BasicSearchController.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/controller/BasicSearchController.java
@@ -22,8 +22,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import static org.uniprot.api.rest.output.UniProtMediaType.LIST_MEDIA_TYPE;
-import static org.uniprot.api.rest.output.UniProtMediaType.RDF_MEDIA_TYPE;
+import static org.uniprot.api.rest.output.UniProtMediaType.*;
 import static org.uniprot.api.rest.output.header.HeaderFactory.createHttpDownloadHeader;
 import static org.uniprot.api.rest.output.header.HeaderFactory.createHttpSearchHeader;
 
@@ -214,11 +213,11 @@ public abstract class BasicSearchController<T> {
             String redirectId, String fromId, MediaType contentType) {
         String path = ServletUriComponentsBuilder.fromCurrentRequest().build().getPath();
         if (path != null) {
-            path =
-                    path.substring(0, path.lastIndexOf('/') + 1)
-                            + redirectId
-                            + "."
-                            + UniProtMediaType.getFileExtension(contentType);
+            String suffix = "";
+            if (!contentType.equals(DEFAULT_MEDIA_TYPE)) {
+                suffix = "." + UniProtMediaType.getFileExtension(contentType);
+            }
+            path = path.substring(0, path.lastIndexOf('/') + 1) + redirectId + suffix;
         }
         return path + "?from=" + fromId;
     }

--- a/common-rest/src/main/java/org/uniprot/api/rest/controller/BasicSearchController.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/controller/BasicSearchController.java
@@ -1,18 +1,6 @@
 package org.uniprot.api.rest.controller;
 
-import static org.uniprot.api.rest.output.UniProtMediaType.LIST_MEDIA_TYPE;
-import static org.uniprot.api.rest.output.UniProtMediaType.RDF_MEDIA_TYPE;
-import static org.uniprot.api.rest.output.header.HeaderFactory.createHttpDownloadHeader;
-import static org.uniprot.api.rest.output.header.HeaderFactory.createHttpSearchHeader;
-
-import java.util.Optional;
-import java.util.stream.Stream;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -28,6 +16,16 @@ import org.uniprot.api.rest.output.context.MessageConverterContext;
 import org.uniprot.api.rest.output.context.MessageConverterContextFactory;
 import org.uniprot.api.rest.pagination.PaginatedResultsEvent;
 import org.uniprot.api.rest.request.StreamRequest;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.uniprot.api.rest.output.UniProtMediaType.LIST_MEDIA_TYPE;
+import static org.uniprot.api.rest.output.UniProtMediaType.RDF_MEDIA_TYPE;
+import static org.uniprot.api.rest.output.header.HeaderFactory.createHttpDownloadHeader;
+import static org.uniprot.api.rest.output.header.HeaderFactory.createHttpSearchHeader;
 
 /**
  * @param <T>
@@ -72,7 +70,9 @@ public abstract class BasicSearchController<T> {
                                                 .header(
                                                         HttpHeaders.LOCATION,
                                                         getLocationURLForId(
-                                                                id, getEntityId(entity))))
+                                                                id,
+                                                                getEntityId(entity),
+                                                                contentType)))
                         .orElse(ResponseEntity.ok());
 
         return responseBuilder.headers(createHttpSearchHeader(contentType)).body(context);
@@ -210,10 +210,15 @@ public abstract class BasicSearchController<T> {
         return getDeferredResultResponseEntity(request, context);
     }
 
-    public static String getLocationURLForId(String redirectId, String fromId) {
+    public static String getLocationURLForId(
+            String redirectId, String fromId, MediaType contentType) {
         String path = ServletUriComponentsBuilder.fromCurrentRequest().build().getPath();
         if (path != null) {
-            path = path.substring(0, path.lastIndexOf('/') + 1) + redirectId;
+            path =
+                    path.substring(0, path.lastIndexOf('/') + 1)
+                            + redirectId
+                            + "."
+                            + UniProtMediaType.getFileExtension(contentType);
         }
         return path + "?from=" + fromId;
     }

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/output/converter/UniProtKBFastaMessageConverter.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/output/converter/UniProtKBFastaMessageConverter.java
@@ -17,6 +17,8 @@ public class UniProtKBFastaMessageConverter
     @Override
     protected void writeEntity(UniProtKBEntry entity, OutputStream outputStream)
             throws IOException {
-        outputStream.write((UniProtKBFastaParser.toFasta(entity) + "\n").getBytes());
+        if (entity.isActive()) {
+            outputStream.write((UniProtKBFastaParser.toFasta(entity) + "\n").getBytes());
+        }
     }
 }

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/output/converter/UniProtKBFlatFileMessageConverter.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/output/converter/UniProtKBFlatFileMessageConverter.java
@@ -17,6 +17,8 @@ public class UniProtKBFlatFileMessageConverter
     @Override
     protected void writeEntity(UniProtKBEntry entity, OutputStream outputStream)
             throws IOException {
-        outputStream.write((UniProtFlatfileWriter.write(entity) + "\n").getBytes());
+        if (entity.isActive()) {
+            outputStream.write((UniProtFlatfileWriter.write(entity) + "\n").getBytes());
+        }
     }
 }

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/output/converter/UniProtKBGffMessageConverter.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/output/converter/UniProtKBGffMessageConverter.java
@@ -18,6 +18,8 @@ public class UniProtKBGffMessageConverter
     @Override
     protected void writeEntity(UniProtKBEntry entity, OutputStream outputStream)
             throws IOException {
-        outputStream.write((UniProtGffParser.convert(entity) + "\n").getBytes());
+        if (entity.isActive()) {
+            outputStream.write((UniProtGffParser.convert(entity) + "\n").getBytes());
+        }
     }
 }

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/output/converter/UniProtKBXmlMessageConverter.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/output/converter/UniProtKBXmlMessageConverter.java
@@ -13,6 +13,9 @@ import org.uniprot.core.uniprotkb.UniProtKBEntry;
 import org.uniprot.core.xml.jaxb.uniprot.Entry;
 import org.uniprot.core.xml.uniprot.UniProtEntryConverter;
 
+import java.io.IOException;
+import java.io.OutputStream;
+
 public class UniProtKBXmlMessageConverter
         extends AbstractXmlMessageConverter<UniProtKBEntry, Entry> {
     private final UniProtEntryConverter converter;
@@ -25,6 +28,13 @@ public class UniProtKBXmlMessageConverter
     @Override
     protected Entry toXml(UniProtKBEntry entity) {
         return converter.toXml(entity);
+    }
+
+    @Override
+    protected void writeEntity(UniProtKBEntry entity, OutputStream outputStream) throws IOException {
+        if (entity.isActive()) {
+            super.writeEntity(entity, outputStream);
+        }
     }
 
     @Override


### PR DESCRIPTION
Hi,

We're trying to change some of our internal ChEMBL code to use your
new beta API. However, I'm having an issue with some calls.
Specifically, if I query with a secondary accession and request text
format, the redirect to the primary accession does not retain the
format request and returns JSON.

This is the URL I am trying:
https://rest.uniprot.org/beta/uniprotkb/Q6QMG6.txt