### PR TITLE
Rate limiter

### DIFF
--- a/aa-rest/src/main/java/org/uniprot/api/aa/repository/ArbaQueryRepository.java
+++ b/aa-rest/src/main/java/org/uniprot/api/aa/repository/ArbaQueryRepository.java
@@ -2,6 +2,7 @@ package org.uniprot.api.aa.repository;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.springframework.stereotype.Repository;
+import org.uniprot.api.common.concurrency.RateLimits;
 import org.uniprot.api.common.repository.search.SolrQueryRepository;
 import org.uniprot.api.common.repository.search.SolrRequestConverter;
 import org.uniprot.store.search.SolrCollection;
@@ -16,7 +17,8 @@ public class ArbaQueryRepository extends SolrQueryRepository<ArbaDocument> {
     public ArbaQueryRepository(
             SolrClient solrClient,
             ArbaFacetConfig facetConfig,
-            SolrRequestConverter requestConverter) {
-        super(solrClient, SolrCollection.arba, ArbaDocument.class, facetConfig, requestConverter);
+            SolrRequestConverter requestConverter,
+            RateLimits rateLimits) {
+        super(solrClient, SolrCollection.arba, ArbaDocument.class, facetConfig, requestConverter,rateLimits);
     }
 }

--- a/aa-rest/src/main/java/org/uniprot/api/aa/repository/UniRuleQueryRepository.java
+++ b/aa-rest/src/main/java/org/uniprot/api/aa/repository/UniRuleQueryRepository.java
@@ -2,6 +2,7 @@ package org.uniprot.api.aa.repository;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.springframework.stereotype.Repository;
+import org.uniprot.api.common.concurrency.RateLimits;
 import org.uniprot.api.common.repository.search.SolrQueryRepository;
 import org.uniprot.api.common.repository.search.SolrRequestConverter;
 import org.uniprot.store.search.SolrCollection;
@@ -16,12 +17,14 @@ public class UniRuleQueryRepository extends SolrQueryRepository<UniRuleDocument>
     public UniRuleQueryRepository(
             SolrClient solrClient,
             UniRuleFacetConfig facetConfig,
-            SolrRequestConverter requestConverter) {
+            SolrRequestConverter requestConverter,
+            RateLimits rateLimits) {
         super(
                 solrClient,
                 SolrCollection.unirule,
                 UniRuleDocument.class,
                 facetConfig,
-                requestConverter);
+                requestConverter,
+                rateLimits);
     }
 }

--- a/common-rest/pom.xml
+++ b/common-rest/pom.xml
@@ -91,6 +91,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>dev.failsafe</groupId>
+			<artifactId>failsafe</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.solr</groupId>
 			<artifactId>solr-solrj</artifactId>
 			<version>${solrj.version}</version>

--- a/common-rest/src/main/java/org/uniprot/api/common/concurrency/RateLimits.java
+++ b/common-rest/src/main/java/org/uniprot/api/common/concurrency/RateLimits.java
@@ -1,0 +1,29 @@
+package org.uniprot.api.common.concurrency;
+
+import dev.failsafe.RateLimiter;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Duration;
+
+/**
+ * Created 13/05/2022
+ *
+ * @author Edd
+ */
+@Builder(toBuilder = true)
+@Getter
+public class RateLimits {
+    // By default set really high -- so that effectively there is no limit,
+    // but tests will work because they hit things at a high rate
+    public static final int SEARCH_RATE_LIMIT_PER_MINUTE = 50000;
+    public static final int GET_ALL_RATE_LIMIT_PER_MINUTE = 50000;
+
+    @Builder.Default
+    private RateLimiter<Object> searchRateLimiter =
+            RateLimiter.burstyBuilder(SEARCH_RATE_LIMIT_PER_MINUTE, Duration.ofMinutes(1)).build();
+
+    @Builder.Default
+    private RateLimiter<Object> getAllRateLimiter =
+            RateLimiter.burstyBuilder(GET_ALL_RATE_LIMIT_PER_MINUTE, Duration.ofMinutes(1)).build();
+}

--- a/common-rest/src/main/java/org/uniprot/api/common/exception/ServiceTooBusyException.java
+++ b/common-rest/src/main/java/org/uniprot/api/common/exception/ServiceTooBusyException.java
@@ -1,0 +1,20 @@
+package org.uniprot.api.common.exception;
+
+/**
+ * Created 13/05/2022
+ *
+ * @author Edd
+ */
+public class ServiceTooBusyException extends RuntimeException {
+    public ServiceTooBusyException() {
+        super();
+    }
+
+    public ServiceTooBusyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ServiceTooBusyException(String message) {
+        super(message);
+    }
+}

--- a/common-rest/src/main/java/org/uniprot/api/rest/respository/RepositoryConfig.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/respository/RepositoryConfig.java
@@ -30,20 +30,20 @@ import static org.uniprot.api.common.concurrency.RateLimits.SEARCH_RATE_LIMIT_PE
  */
 @Configuration
 public class RepositoryConfig {
-    @Value("${rateLimitPerSecond.search:" + SEARCH_RATE_LIMIT_PER_MINUTE + "}")
-    private int searchRateLimitPerSecond;
+    @Value("${rateLimitPerMinute.search:" + SEARCH_RATE_LIMIT_PER_MINUTE + "}")
+    private int searchRateLimit;
 
-    @Value("${rateLimitPerSecond.getAll:" + GET_ALL_RATE_LIMIT_PER_MINUTE + "}")
-    private int getAllRateLimitPerSecond;
+    @Value("${rateLimitPerMinute.getAll:" + GET_ALL_RATE_LIMIT_PER_MINUTE + "}")
+    private int getAllRateLimit;
 
     @Bean
     public RateLimits rateLimits() {
         return RateLimits.builder()
                 .searchRateLimiter(
-                        RateLimiter.smoothBuilder(searchRateLimitPerSecond, Duration.ofSeconds(1))
+                        RateLimiter.smoothBuilder(searchRateLimit, Duration.ofSeconds(1))
                                 .build())
                 .getAllRateLimiter(
-                        RateLimiter.smoothBuilder(getAllRateLimitPerSecond, Duration.ofSeconds(1))
+                        RateLimiter.smoothBuilder(getAllRateLimit, Duration.ofSeconds(1))
                                 .build())
                 .build();
     }

--- a/common-rest/src/main/java/org/uniprot/api/rest/respository/RepositoryConfig.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/respository/RepositoryConfig.java
@@ -1,9 +1,6 @@
 package org.uniprot.api.rest.respository;
 
-import static java.util.Arrays.asList;
-
-import java.util.Optional;
-
+import dev.failsafe.RateLimiter;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.solr.client.solrj.SolrClient;
@@ -12,10 +9,19 @@ import org.apache.solr.client.solrj.impl.HttpClientUtil;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.uniprot.api.common.concurrency.RateLimits;
 import org.uniprot.api.common.repository.search.SolrRequestConverter;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static java.util.Arrays.asList;
+import static org.uniprot.api.common.concurrency.RateLimits.GET_ALL_RATE_LIMIT_PER_MINUTE;
+import static org.uniprot.api.common.concurrency.RateLimits.SEARCH_RATE_LIMIT_PER_MINUTE;
 
 /**
  * Configure solr repository beans, that are used to retrieve data from a solr instance.
@@ -24,6 +30,23 @@ import org.uniprot.api.common.repository.search.SolrRequestConverter;
  */
 @Configuration
 public class RepositoryConfig {
+    @Value("${rateLimitPerSecond.search:" + SEARCH_RATE_LIMIT_PER_MINUTE + "}")
+    private int searchRateLimitPerSecond;
+
+    @Value("${rateLimitPerSecond.getAll:" + GET_ALL_RATE_LIMIT_PER_MINUTE + "}")
+    private int getAllRateLimitPerSecond;
+
+    @Bean
+    public RateLimits rateLimits() {
+        return RateLimits.builder()
+                .searchRateLimiter(
+                        RateLimiter.smoothBuilder(searchRateLimitPerSecond, Duration.ofSeconds(1))
+                                .build())
+                .getAllRateLimiter(
+                        RateLimiter.smoothBuilder(getAllRateLimitPerSecond, Duration.ofSeconds(1))
+                                .build())
+                .build();
+    }
 
     @Bean
     public RepositoryConfigProperties repositoryConfigProperties() {

--- a/common-rest/src/main/java/org/uniprot/api/rest/validation/error/ResponseExceptionHandler.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/validation/error/ResponseExceptionHandler.java
@@ -1,25 +1,5 @@
 package org.uniprot.api.rest.validation.error;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
-import static org.uniprot.api.rest.output.UniProtMediaType.DEFAULT_MEDIA_TYPE_VALUE;
-import static org.uniprot.api.rest.output.UniProtMediaType.UNKNOWN_MEDIA_TYPE;
-import static org.uniprot.api.rest.request.HttpServletRequestContentTypeMutator.ERROR_MESSAGE_ATTRIBUTE;
-import static org.uniprot.api.rest.validation.error.ResponseExceptionHelper.addDebugError;
-import static org.uniprot.api.rest.validation.error.ResponseExceptionHelper.getBadRequestResponseEntity;
-import static org.uniprot.api.rest.validation.error.ResponseExceptionHelper.getContentTypeFromRequest;
-import static org.uniprot.core.util.Utils.nullOrEmpty;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-
 import org.apache.catalina.connector.ClientAbortException;
 import org.owasp.encoder.Encode;
 import org.slf4j.Logger;
@@ -44,6 +24,23 @@ import org.uniprot.api.common.repository.search.QueryRetrievalException;
 import org.uniprot.api.rest.output.converter.StopStreamException;
 import org.uniprot.api.rest.request.MutableHttpServletRequest;
 import org.uniprot.core.util.Utils;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.uniprot.api.rest.output.UniProtMediaType.DEFAULT_MEDIA_TYPE_VALUE;
+import static org.uniprot.api.rest.output.UniProtMediaType.UNKNOWN_MEDIA_TYPE;
+import static org.uniprot.api.rest.request.HttpServletRequestContentTypeMutator.ERROR_MESSAGE_ATTRIBUTE;
+import static org.uniprot.api.rest.validation.error.ResponseExceptionHelper.*;
+import static org.uniprot.core.util.Utils.nullOrEmpty;
 
 /**
  * Captures exceptions raised by the application, and handles them in a tailored way.
@@ -138,6 +135,16 @@ public class ResponseExceptionHandler {
         ErrorInfo error = new ErrorInfo(url, messages);
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .contentType(getContentTypeFromRequest(request))
+                .body(error);
+    }
+
+    @ExceptionHandler({ServiceTooBusyException.class})
+    public ResponseEntity<ErrorInfo> handleServiceBusy(HttpServletRequest request) {
+        String url = Encode.forHtml(request.getRequestURL().toString());
+        ErrorInfo error = new ErrorInfo(url, List.of("Please try again"));
+
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
                 .contentType(getContentTypeFromRequest(request))
                 .body(error);
     }

--- a/common-rest/src/test/java/org/uniprot/api/common/repository/search/SolrQueryRepositoryIT.java
+++ b/common-rest/src/test/java/org/uniprot/api/common/repository/search/SolrQueryRepositoryIT.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.uniprot.api.common.concurrency.RateLimits;
 import org.uniprot.api.common.repository.search.page.impl.CursorPage;
 import org.uniprot.api.rest.respository.facet.impl.UniProtKBFacetConfig;
 import org.uniprot.store.indexer.DataStoreManager;
@@ -53,6 +54,7 @@ class SolrQueryRepositoryIT {
             storeManager.addSolrClient(DataStoreManager.StoreType.UNIPROT, SolrCollection.uniprot);
             SolrClient solrClient = storeManager.getSolrClient(DataStoreManager.StoreType.UNIPROT);
             queryRepo = new GeneralSolrQueryRepository(solrClient, facetConfig);
+            System.out.println("thing");
         } catch (Exception e) {
             fail("Error to setup SolrQueryRepositoryTest", e);
         }
@@ -411,7 +413,8 @@ class SolrQueryRepositoryIT {
                     SolrCollection.uniprot,
                     UniProtDocument.class,
                     facetConfig,
-                    new GeneralSolrRequestConverter());
+                    new GeneralSolrRequestConverter(),
+                    RateLimits.builder().build());
         }
     }
 

--- a/help-centre-rest/pom.xml
+++ b/help-centre-rest/pom.xml
@@ -93,7 +93,7 @@
 		</dependency>
 
 		<dependency>
-			<groupId>net.jodah</groupId>
+			<groupId>dev.failsafe</groupId>
 			<artifactId>failsafe</artifactId>
 		</dependency>
 

--- a/help-centre-rest/src/main/java/org/uniprot/api/help/centre/repository/HelpCentreQueryRepository.java
+++ b/help-centre-rest/src/main/java/org/uniprot/api/help/centre/repository/HelpCentreQueryRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.springframework.stereotype.Repository;
+import org.uniprot.api.common.concurrency.RateLimits;
 import org.uniprot.api.common.repository.search.SolrQueryRepository;
 import org.uniprot.api.common.repository.search.SolrRequestConverter;
 import org.uniprot.core.util.Utils;
@@ -22,8 +23,9 @@ public class HelpCentreQueryRepository extends SolrQueryRepository<HelpDocument>
     protected HelpCentreQueryRepository(
             SolrClient solrClient,
             HelpCentreFacetConfig facetConfig,
-            SolrRequestConverter requestConverter) {
-        super(solrClient, SolrCollection.help, HelpDocument.class, facetConfig, requestConverter);
+            SolrRequestConverter requestConverter,
+            RateLimits rateLimits) {
+        super(solrClient, SolrCollection.help, HelpDocument.class, facetConfig, requestConverter, rateLimits);
     }
 
     @Override

--- a/help-centre-rest/src/test/java/org/uniprot/api/help/centre/repository/HelpCentreQueryRepositoryTest.java
+++ b/help-centre-rest/src/test/java/org/uniprot/api/help/centre/repository/HelpCentreQueryRepositoryTest.java
@@ -1,14 +1,15 @@
 package org.uniprot.api.help.centre.repository;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.uniprot.api.common.concurrency.RateLimits;
+import org.uniprot.store.search.document.help.HelpDocument;
 
 import java.util.List;
 import java.util.Map;
 
-import org.apache.solr.client.solrj.response.QueryResponse;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.uniprot.store.search.document.help.HelpDocument;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author lgonzales
@@ -26,7 +27,8 @@ class HelpCentreQueryRepositoryTest {
         QueryResponse queryResults = Mockito.mock(QueryResponse.class);
         Mockito.when(queryResults.getBeans(HelpDocument.class)).thenReturn(List.of(doc));
         Mockito.when(queryResults.getHighlighting()).thenReturn(highlight);
-        HelpCentreQueryRepository repository = new HelpCentreQueryRepository(null, null, null);
+        HelpCentreQueryRepository repository =
+                new HelpCentreQueryRepository(null, null, null, RateLimits.builder().build());
         List<HelpDocument> result = repository.getResponseDocuments(queryResults);
         assertNotNull(result);
         assertEquals(1, result.size());
@@ -45,7 +47,8 @@ class HelpCentreQueryRepositoryTest {
         QueryResponse queryResults = Mockito.mock(QueryResponse.class);
         Mockito.when(queryResults.getBeans(HelpDocument.class)).thenReturn(List.of(doc));
 
-        HelpCentreQueryRepository repository = new HelpCentreQueryRepository(null, null, null);
+        HelpCentreQueryRepository repository =
+                new HelpCentreQueryRepository(null, null, null, RateLimits.builder().build());
         List<HelpDocument> result = repository.getResponseDocuments(queryResults);
 
         assertNotNull(result);

--- a/idmapping-rest/pom.xml
+++ b/idmapping-rest/pom.xml
@@ -89,7 +89,7 @@
 		</dependency>
 
 		<dependency>
-			<groupId>net.jodah</groupId>
+			<groupId>dev.failsafe</groupId>
 			<artifactId>failsafe</artifactId>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
 		<spring.boot.version>2.3.1.RELEASE</spring.boot.version>
 		<http-uniprot-private-url>https://wwwdev.ebi.ac.uk/uniprot/artifactory</http-uniprot-private-url>
-		<failsafe.version>2.0.1</failsafe.version>
+		<failsafe.version>3.2.3</failsafe.version>
 		<solr.core>8.5.2</solr.core>
 		<solrj.version>8.5.2</solrj.version>
 		<hamcrest-library.version>2.2</hamcrest-library.version>
@@ -81,7 +81,7 @@
 		<dependencies>
 
 			<dependency>
-				<groupId>net.jodah</groupId>
+				<groupId>dev.failsafe</groupId>
 				<artifactId>failsafe</artifactId>
 				<version>${failsafe.version}</version>
 			</dependency>

--- a/proteome-rest/src/main/java/org/uniprot/api/proteome/repository/GeneCentricQueryRepository.java
+++ b/proteome-rest/src/main/java/org/uniprot/api/proteome/repository/GeneCentricQueryRepository.java
@@ -2,6 +2,7 @@ package org.uniprot.api.proteome.repository;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.springframework.stereotype.Repository;
+import org.uniprot.api.common.concurrency.RateLimits;
 import org.uniprot.api.common.repository.search.SolrQueryRepository;
 import org.uniprot.api.common.repository.search.SolrRequestConverter;
 import org.uniprot.store.search.SolrCollection;
@@ -17,12 +18,14 @@ public class GeneCentricQueryRepository extends SolrQueryRepository<GeneCentricD
     public GeneCentricQueryRepository(
             SolrClient solrClient,
             GeneCentricFacetConfig facetConfig,
-            SolrRequestConverter requestConverter) {
+            SolrRequestConverter requestConverter,
+            RateLimits rateLimits) {
         super(
                 solrClient,
                 SolrCollection.genecentric,
                 GeneCentricDocument.class,
                 facetConfig,
-                requestConverter);
+                requestConverter,
+                rateLimits);
     }
 }

--- a/proteome-rest/src/main/java/org/uniprot/api/proteome/repository/ProteomeQueryRepository.java
+++ b/proteome-rest/src/main/java/org/uniprot/api/proteome/repository/ProteomeQueryRepository.java
@@ -2,6 +2,7 @@ package org.uniprot.api.proteome.repository;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.springframework.stereotype.Repository;
+import org.uniprot.api.common.concurrency.RateLimits;
 import org.uniprot.api.common.repository.search.SolrQueryRepository;
 import org.uniprot.api.common.repository.search.SolrRequestConverter;
 import org.uniprot.store.search.SolrCollection;
@@ -17,12 +18,14 @@ public class ProteomeQueryRepository extends SolrQueryRepository<ProteomeDocumen
     public ProteomeQueryRepository(
             SolrClient solrClient,
             ProteomeFacetConfig facetConfig,
-            SolrRequestConverter requestConverter) {
+            SolrRequestConverter requestConverter,
+            RateLimits rateLimits) {
         super(
                 solrClient,
                 SolrCollection.proteome,
                 ProteomeDocument.class,
                 facetConfig,
-                requestConverter);
+                requestConverter,
+                rateLimits);
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/crossref/repository/CrossRefRepository.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/crossref/repository/CrossRefRepository.java
@@ -2,6 +2,7 @@ package org.uniprot.api.support.data.crossref.repository;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.springframework.stereotype.Repository;
+import org.uniprot.api.common.concurrency.RateLimits;
 import org.uniprot.api.common.repository.search.SolrQueryRepository;
 import org.uniprot.api.common.repository.search.SolrRequestConverter;
 import org.uniprot.api.support.data.crossref.request.CrossRefFacetConfig;
@@ -13,12 +14,14 @@ public class CrossRefRepository extends SolrQueryRepository<CrossRefDocument> {
     public CrossRefRepository(
             SolrClient solrClient,
             SolrRequestConverter requestConverter,
-            CrossRefFacetConfig facetConfig) {
+            CrossRefFacetConfig facetConfig,
+            RateLimits rateLimits) {
         super(
                 solrClient,
                 SolrCollection.crossref,
                 CrossRefDocument.class,
                 facetConfig,
-                requestConverter);
+                requestConverter,
+                rateLimits);
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/disease/repository/DiseaseRepository.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/disease/repository/DiseaseRepository.java
@@ -2,6 +2,7 @@ package org.uniprot.api.support.data.disease.repository;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.springframework.stereotype.Repository;
+import org.uniprot.api.common.concurrency.RateLimits;
 import org.uniprot.api.common.repository.search.SolrQueryRepository;
 import org.uniprot.api.common.repository.search.SolrRequestConverter;
 import org.uniprot.store.search.SolrCollection;
@@ -9,7 +10,14 @@ import org.uniprot.store.search.document.disease.DiseaseDocument;
 
 @Repository
 public class DiseaseRepository extends SolrQueryRepository<DiseaseDocument> {
-    public DiseaseRepository(SolrClient solrClient, SolrRequestConverter requestConverter) {
-        super(solrClient, SolrCollection.disease, DiseaseDocument.class, null, requestConverter);
+    public DiseaseRepository(
+            SolrClient solrClient, SolrRequestConverter requestConverter, RateLimits rateLimits) {
+        super(
+                solrClient,
+                SolrCollection.disease,
+                DiseaseDocument.class,
+                null,
+                requestConverter,
+                rateLimits);
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/keyword/repository/KeywordRepository.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/keyword/repository/KeywordRepository.java
@@ -2,6 +2,7 @@ package org.uniprot.api.support.data.keyword.repository;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.springframework.stereotype.Repository;
+import org.uniprot.api.common.concurrency.RateLimits;
 import org.uniprot.api.common.repository.search.SolrQueryRepository;
 import org.uniprot.api.common.repository.search.SolrRequestConverter;
 import org.uniprot.store.search.SolrCollection;
@@ -14,12 +15,14 @@ public class KeywordRepository extends SolrQueryRepository<KeywordDocument> {
     protected KeywordRepository(
             SolrClient solrClient,
             SolrRequestConverter requestConverter,
-            KeywordFacetConfig facetConfig) {
+            KeywordFacetConfig facetConfig,
+            RateLimits rateLimits) {
         super(
                 solrClient,
                 SolrCollection.keyword,
                 KeywordDocument.class,
                 facetConfig,
-                requestConverter);
+                requestConverter,
+                rateLimits);
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/literature/repository/LiteratureRepository.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/literature/repository/LiteratureRepository.java
@@ -2,6 +2,7 @@ package org.uniprot.api.support.data.literature.repository;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.springframework.stereotype.Repository;
+import org.uniprot.api.common.concurrency.RateLimits;
 import org.uniprot.api.common.repository.search.SolrQueryRepository;
 import org.uniprot.api.common.repository.search.SolrRequestConverter;
 import org.uniprot.store.search.SolrCollection;
@@ -17,12 +18,12 @@ public class LiteratureRepository extends SolrQueryRepository<LiteratureDocument
     protected LiteratureRepository(
             SolrClient solrClient,
             LiteratureFacetConfig facetConfig,
-            SolrRequestConverter requestConverter) {
+            SolrRequestConverter requestConverter, RateLimits rateLimits) {
         super(
                 solrClient,
                 SolrCollection.literature,
                 LiteratureDocument.class,
                 facetConfig,
-                requestConverter);
+                requestConverter, rateLimits);
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/subcellular/repository/SubcellularLocationRepository.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/subcellular/repository/SubcellularLocationRepository.java
@@ -2,6 +2,7 @@ package org.uniprot.api.support.data.subcellular.repository;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.springframework.stereotype.Repository;
+import org.uniprot.api.common.concurrency.RateLimits;
 import org.uniprot.api.common.repository.search.SolrQueryRepository;
 import org.uniprot.api.common.repository.search.SolrRequestConverter;
 import org.uniprot.store.search.SolrCollection;
@@ -16,12 +17,12 @@ public class SubcellularLocationRepository
         extends SolrQueryRepository<SubcellularLocationDocument> {
 
     protected SubcellularLocationRepository(
-            SolrClient solrClient, SolrRequestConverter requestConverter) {
+            SolrClient solrClient, SolrRequestConverter requestConverter, RateLimits rateLimits) {
         super(
                 solrClient,
                 SolrCollection.subcellularlocation,
                 SubcellularLocationDocument.class,
                 null,
-                requestConverter);
+                requestConverter, rateLimits);
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/taxonomy/repository/TaxonomyRepository.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/taxonomy/repository/TaxonomyRepository.java
@@ -2,6 +2,7 @@ package org.uniprot.api.support.data.taxonomy.repository;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.springframework.stereotype.Repository;
+import org.uniprot.api.common.concurrency.RateLimits;
 import org.uniprot.api.common.repository.search.SolrQueryRepository;
 import org.uniprot.api.common.repository.search.SolrRequestConverter;
 import org.uniprot.api.support.data.taxonomy.request.TaxonomyFacetConfig;
@@ -14,12 +15,12 @@ public class TaxonomyRepository extends SolrQueryRepository<TaxonomyDocument> {
     protected TaxonomyRepository(
             SolrClient solrClient,
             TaxonomyFacetConfig facetConfig,
-            SolrRequestConverter requestConverter) {
+            SolrRequestConverter requestConverter, RateLimits rateLimits) {
         super(
                 solrClient,
                 SolrCollection.taxonomy,
                 TaxonomyDocument.class,
                 facetConfig,
-                requestConverter);
+                requestConverter, rateLimits);
     }
 }

--- a/uniparc-rest/src/main/java/org/uniprot/api/uniparc/repository/UniParcQueryRepository.java
+++ b/uniparc-rest/src/main/java/org/uniprot/api/uniparc/repository/UniParcQueryRepository.java
@@ -2,6 +2,7 @@ package org.uniprot.api.uniparc.repository;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.springframework.stereotype.Repository;
+import org.uniprot.api.common.concurrency.RateLimits;
 import org.uniprot.api.common.repository.search.SolrQueryRepository;
 import org.uniprot.api.common.repository.search.SolrRequestConverter;
 import org.uniprot.api.rest.respository.facet.impl.UniParcFacetConfig;
@@ -17,12 +18,12 @@ public class UniParcQueryRepository extends SolrQueryRepository<UniParcDocument>
     public UniParcQueryRepository(
             SolrClient solrClient,
             UniParcFacetConfig facetConfig,
-            SolrRequestConverter requestConverter) {
+            SolrRequestConverter requestConverter, RateLimits rateLimits) {
         super(
                 solrClient,
                 SolrCollection.uniparc,
                 UniParcDocument.class,
                 facetConfig,
-                requestConverter);
+                requestConverter, rateLimits);
     }
 }

--- a/uniprotkb-rest/pom.xml
+++ b/uniprotkb-rest/pom.xml
@@ -126,7 +126,7 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>net.jodah</groupId>
+			<groupId>dev.failsafe</groupId>
 			<artifactId>failsafe</artifactId>
 		</dependency>
 

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/repository/search/impl/LiteratureRepository.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/repository/search/impl/LiteratureRepository.java
@@ -2,6 +2,7 @@ package org.uniprot.api.uniprotkb.repository.search.impl;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.springframework.stereotype.Repository;
+import org.uniprot.api.common.concurrency.RateLimits;
 import org.uniprot.api.common.repository.search.SolrQueryRepository;
 import org.uniprot.api.common.repository.search.SolrRequestConverter;
 import org.uniprot.store.search.SolrCollection;
@@ -14,12 +15,12 @@ import org.uniprot.store.search.document.literature.LiteratureDocument;
 @Repository
 public class LiteratureRepository extends SolrQueryRepository<LiteratureDocument> {
 
-    protected LiteratureRepository(SolrClient solrClient, SolrRequestConverter requestConverter) {
+    protected LiteratureRepository(SolrClient solrClient, SolrRequestConverter requestConverter, RateLimits rateLimits) {
         super(
                 solrClient,
                 SolrCollection.literature,
                 LiteratureDocument.class,
                 null,
-                requestConverter);
+                requestConverter, rateLimits);
     }
 }

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/repository/search/impl/PublicationRepository.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/repository/search/impl/PublicationRepository.java
@@ -2,6 +2,7 @@ package org.uniprot.api.uniprotkb.repository.search.impl;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.springframework.stereotype.Repository;
+import org.uniprot.api.common.concurrency.RateLimits;
 import org.uniprot.api.common.repository.search.SolrQueryRepository;
 import org.uniprot.api.common.repository.search.SolrRequestConverter;
 import org.uniprot.api.uniprotkb.service.PublicationFacetConfig;
@@ -14,12 +15,12 @@ public class PublicationRepository extends SolrQueryRepository<PublicationDocume
     protected PublicationRepository(
             SolrClient solrClient,
             PublicationFacetConfig facetConfig2,
-            SolrRequestConverter requestConverter) {
+            SolrRequestConverter requestConverter, RateLimits rateLimits) {
         super(
                 solrClient,
                 SolrCollection.publication,
                 PublicationDocument.class,
                 facetConfig2,
-                requestConverter);
+                requestConverter, rateLimits);
     }
 }

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/repository/search/impl/TaxonomyRepository.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/repository/search/impl/TaxonomyRepository.java
@@ -2,6 +2,7 @@ package org.uniprot.api.uniprotkb.repository.search.impl;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.springframework.stereotype.Repository;
+import org.uniprot.api.common.concurrency.RateLimits;
 import org.uniprot.api.common.repository.search.SolrQueryRepository;
 import org.uniprot.api.common.repository.search.SolrRequestConverter;
 import org.uniprot.store.search.SolrCollection;
@@ -16,12 +17,12 @@ public class TaxonomyRepository extends SolrQueryRepository<TaxonomyDocument> {
     protected TaxonomyRepository(
             SolrClient solrClient,
             TaxonomyFacetConfig facetConfig,
-            SolrRequestConverter requestConverter) {
+            SolrRequestConverter requestConverter, RateLimits rateLimits) {
         super(
                 solrClient,
                 SolrCollection.taxonomy,
                 TaxonomyDocument.class,
                 facetConfig,
-                requestConverter);
+                requestConverter, rateLimits);
     }
 }

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/repository/search/impl/UniprotQueryRepository.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/repository/search/impl/UniprotQueryRepository.java
@@ -2,6 +2,7 @@ package org.uniprot.api.uniprotkb.repository.search.impl;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.springframework.stereotype.Repository;
+import org.uniprot.api.common.concurrency.RateLimits;
 import org.uniprot.api.common.repository.search.SolrQueryRepository;
 import org.uniprot.api.common.repository.search.SolrRequestConverter;
 import org.uniprot.api.rest.respository.facet.impl.UniProtKBFacetConfig;
@@ -18,12 +19,12 @@ public class UniprotQueryRepository extends SolrQueryRepository<UniProtDocument>
     public UniprotQueryRepository(
             SolrClient solrClient,
             UniProtKBFacetConfig facetConfig,
-            SolrRequestConverter requestConverter) {
+            SolrRequestConverter requestConverter, RateLimits rateLimits) {
         super(
                 solrClient,
                 SolrCollection.uniprot,
                 UniProtDocument.class,
                 facetConfig,
-                requestConverter);
+                requestConverter, rateLimits);
     }
 }

--- a/uniref-rest/src/main/java/org/uniprot/api/uniref/repository/UniRefQueryRepository.java
+++ b/uniref-rest/src/main/java/org/uniprot/api/uniref/repository/UniRefQueryRepository.java
@@ -2,6 +2,7 @@ package org.uniprot.api.uniref.repository;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.springframework.stereotype.Repository;
+import org.uniprot.api.common.concurrency.RateLimits;
 import org.uniprot.api.common.repository.search.SolrQueryRepository;
 import org.uniprot.api.common.repository.search.SolrRequestConverter;
 import org.uniprot.api.rest.respository.facet.impl.UniRefFacetConfig;
@@ -17,12 +18,14 @@ public class UniRefQueryRepository extends SolrQueryRepository<UniRefDocument> {
     public UniRefQueryRepository(
             SolrClient solrClient,
             UniRefFacetConfig facetConfig,
-            SolrRequestConverter requestConverter) {
+            SolrRequestConverter requestConverter,
+            RateLimits rateLimits) {
         super(
                 solrClient,
                 SolrCollection.uniref,
                 UniRefDocument.class,
                 facetConfig,
-                requestConverter);
+                requestConverter,
+                rateLimits);
     }
 }


### PR DESCRIPTION
Note that this implementation applies a configurable limit for searches and getAll (via properties: rateLimitPerMinute.search / rateLimitPerMinute.getAll). Also note, this applies the limit at the point of making a request to Solr (i.e., in the *SolrQueryRepository classes) -- I did this as all requests eventually go through this class. However, alternatively, we could apply the rate limit at a high point, at the Controller / Service layer (but in multiple places), but there maybe more places to apply the change to. This approach is essentially protecting Solr (and by proxy, Voldemort).