### PR TITLE
TRM-29250: Update idmapping/fields

### DIFF
--- a/support-data-rest/src/test/java/org/uniprot/api/support/data/configure/controller/IdMappingConfigureControllerIT.java
+++ b/support-data-rest/src/test/java/org/uniprot/api/support/data/configure/controller/IdMappingConfigureControllerIT.java
@@ -75,14 +75,14 @@ class IdMappingConfigureControllerIT {
                         jsonPath(
                                 "$.groups.[?(@.groupName=='UniProt')].items.*.uriLink",
                                 contains(
-                                        "https://www.uniprot.org/uniprot/%id",
-                                        "https://www.uniprot.org/uniprot/%id",
-                                        "https://www.uniprot.org/uniprot/%id",
+                                        "https://www.uniprot.org/uniprot/%id/entry",
+                                        "https://www.uniprot.org/uniprot/%id/entry",
+                                        "https://www.uniprot.org/uniprot/%id/entry",
+                                        "https://www.uniprot.org/uniparc/%id/entry",
+                                        "https://www.uniprot.org/uniref/%id/entry",
+                                        "https://www.uniprot.org/uniref/%id/entry",
+                                        "https://www.uniprot.org/uniref/%id/entry",
                                         null,
-                                        "https://www.uniprot.org/uniref/%id",
-                                        "https://www.uniprot.org/uniref/%id",
-                                        "https://www.uniprot.org/uniref/%id",
-                                        "https://proteininformationresource.org/cgi-bin/nbrfget?uid=%id",
                                         null)))
                 .andExpect(
                         jsonPath(

--- a/support-data-rest/src/test/java/org/uniprot/api/support/data/configure/controller/IdMappingConfigureControllerIT.java
+++ b/support-data-rest/src/test/java/org/uniprot/api/support/data/configure/controller/IdMappingConfigureControllerIT.java
@@ -79,9 +79,9 @@ class IdMappingConfigureControllerIT {
                                         "https://www.uniprot.org/uniprot/%id/entry",
                                         "https://www.uniprot.org/uniprot/%id/entry",
                                         "https://www.uniprot.org/uniparc/%id/entry",
-                                        "https://www.uniprot.org/uniref/%id/entry",
-                                        "https://www.uniprot.org/uniref/%id/entry",
-                                        "https://www.uniprot.org/uniref/%id/entry",
+                                        "https://www.uniprot.org/uniref/%id",
+                                        "https://www.uniprot.org/uniref/%id",
+                                        "https://www.uniprot.org/uniref/%id",
                                         null,
                                         null)))
                 .andExpect(


### PR DESCRIPTION
- Remove set uriLink for Gene Name, set to null
- Use the new URL template for UniProtKB results (/uniprotkb/%id/entry)
- Define a uriLink for UniParc and UniRef (at the moment it's null)