### PR TITLE
TRM-28917: Accessions endpoint allow canonical isoform for trembl

### DIFF
--- a/common-rest/src/main/java/org/uniprot/api/common/repository/solrstream/SolrStreamFacetRequest.java
+++ b/common-rest/src/main/java/org/uniprot/api/common/repository/solrstream/SolrStreamFacetRequest.java
@@ -87,22 +87,6 @@ public class SolrStreamFacetRequest {
             SolrQueryConfig solrQueryConfig,
             UniProtDataType uniProtDataType,
             String solrIdField,
-            List<String> ids,
-            SearchRequest searchRequest) {
-        return createSolrStreamFacetRequest(
-                solrQueryConfig,
-                uniProtDataType,
-                solrIdField,
-                solrIdField,
-                ids,
-                searchRequest,
-                false);
-    }
-
-    public static SolrStreamFacetRequest createSolrStreamFacetRequest(
-            SolrQueryConfig solrQueryConfig,
-            UniProtDataType uniProtDataType,
-            String solrIdField,
             String termsQueryField,
             List<String> ids,
             SearchRequest searchRequest,

--- a/common-rest/src/main/java/org/uniprot/api/rest/request/UniProtKBRequestUtil.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/request/UniProtKBRequestUtil.java
@@ -28,7 +28,7 @@ public class UniProtKBRequestUtil {
 
     private static final Pattern ACCESSION_REGEX_ISOFORM =
             Pattern.compile(FieldRegexConstants.UNIPROTKB_ACCESSION_REGEX);
-    private static final String DASH = "-";
+    public static final String DASH = "-";
 
     public static boolean needsToFilterIsoform(
             String accessionIdField,

--- a/common-rest/src/main/java/org/uniprot/api/rest/service/StoreStreamerSearchService.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/service/StoreStreamerSearchService.java
@@ -20,10 +20,13 @@ import org.uniprot.api.common.repository.solrstream.SolrStreamFacetRequest;
 import org.uniprot.api.common.repository.stream.store.StoreStreamer;
 import org.uniprot.api.rest.request.IdsSearchRequest;
 import org.uniprot.api.rest.request.StreamRequest;
+import org.uniprot.api.rest.request.UniProtKBRequestUtil;
 import org.uniprot.api.rest.search.AbstractSolrSortClause;
 import org.uniprot.core.util.Utils;
 import org.uniprot.store.config.UniProtDataType;
 import org.uniprot.store.search.document.Document;
+
+import static org.uniprot.api.rest.request.UniProtKBRequestUtil.*;
 
 public abstract class StoreStreamerSearchService<D extends Document, R>
         extends BasicSearchService<D, R> {
@@ -161,6 +164,6 @@ public abstract class StoreStreamerSearchService<D extends Document, R>
     }
 
     private boolean hasIsoformIds(List<String> ids) {
-        return ids.stream().anyMatch(id -> id.contains("-"));
+        return ids.stream().anyMatch(id -> id.contains(DASH));
     }
 }

--- a/common-rest/src/main/java/org/uniprot/api/rest/service/StoreStreamerSearchService.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/service/StoreStreamerSearchService.java
@@ -80,15 +80,16 @@ public abstract class StoreStreamerSearchService<D extends Document, R>
     }
 
     public QueryResult<R> getByIds(IdsSearchRequest idsRequest) {
+        boolean hasIsoformIds = hasIsoformIds(idsRequest.getIdList());
         SolrStreamFacetResponse solrStreamResponse =
-                solrStreamNeeded(idsRequest)
-                        ? searchBySolrStream(idsRequest)
+                solrStreamNeeded(idsRequest, hasIsoformIds)
+                        ? searchBySolrStream(idsRequest, hasIsoformIds)
                         : new SolrStreamFacetResponse();
 
         // use the ids returned by solr stream if query filter is passed or sort field is passed
         // otherwise use the passed ids
         List<String> ids =
-                needSolrReturnedAccessions(idsRequest)
+                needSolrReturnedAccessions(idsRequest, hasIsoformIds)
                         ? solrStreamResponse.getIds()
                         : idsRequest.getIdList();
         // default page size to number of ids passed
@@ -125,28 +126,41 @@ public abstract class StoreStreamerSearchService<D extends Document, R>
 
     protected abstract String getSolrIdField();
 
-    private SolrStreamFacetResponse searchBySolrStream(IdsSearchRequest idsRequest) {
+    protected String getTermsQueryField() {
+        return getSolrIdField();
+    }
+
+    private SolrStreamFacetResponse searchBySolrStream(
+            IdsSearchRequest idsRequest, boolean includeIsoform) {
         SolrStreamFacetRequest solrStreamRequest =
                 SolrStreamFacetRequest.createSolrStreamFacetRequest(
                         this.solrQueryConfig,
                         getUniProtDataType(),
                         getSolrIdField(),
+                        getTermsQueryField(),
                         idsRequest.getIdList(),
-                        idsRequest);
+                        idsRequest,
+                        includeIsoform);
         TupleStream tupleStream = this.tupleStreamTemplate.create(solrStreamRequest, facetConfig);
         return this.tupleStreamConverter.convert(tupleStream, idsRequest.getFacetList());
     }
 
-    private boolean solrStreamNeeded(IdsSearchRequest idsRequest) {
+    private boolean solrStreamNeeded(IdsSearchRequest idsRequest, boolean hasIsoformIds) {
         return (Utils.nullOrEmpty(idsRequest.getCursor())
                         && Utils.notNullNotEmpty(idsRequest.getFacetList())
                         && !idsRequest.isDownload())
                 || Utils.notNullNotEmpty(idsRequest.getQuery())
-                || Utils.notNullNotEmpty(idsRequest.getSort());
+                || Utils.notNullNotEmpty(idsRequest.getSort())
+                || hasIsoformIds;
     }
 
-    private boolean needSolrReturnedAccessions(IdsSearchRequest idsRequest) {
+    private boolean needSolrReturnedAccessions(IdsSearchRequest idsRequest, boolean hasIsoformIds) {
         return Utils.notNullNotEmpty(idsRequest.getQuery())
-                || Utils.notNullNotEmpty(idsRequest.getSort());
+                || Utils.notNullNotEmpty(idsRequest.getSort())
+                || hasIsoformIds;
+    }
+
+    private boolean hasIsoformIds(List<String> ids) {
+        return ids.stream().anyMatch(id -> id.contains("-"));
     }
 }

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/service/UniProtEntryService.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/service/UniProtEntryService.java
@@ -52,7 +52,8 @@ import org.uniprot.store.search.document.uniprot.UniProtDocument;
 @Import(UniProtSolrQueryConfig.class)
 public class UniProtEntryService
         extends StoreStreamerSearchService<UniProtDocument, UniProtKBEntry> {
-    public static final String ACCESSION = "accession_id";
+    public static final String ACCESSION_ID = "accession_id";
+    public static final String ACCESSION = "accession";
     public static final String PROTEIN_ID = "id";
     public static final String IS_ISOFORM = "is_isoform";
     public static final String CANONICAL_ISOFORM = "-1";
@@ -118,7 +119,7 @@ public class UniProtEntryService
 
     @Override
     protected SearchFieldItem getIdField() {
-        return searchFieldConfig.getSearchFieldItemByName(ACCESSION);
+        return searchFieldConfig.getSearchFieldItemByName(ACCESSION_ID);
     }
 
     @Override
@@ -162,7 +163,7 @@ public class UniProtEntryService
 
     private SolrRequest buildSolrRequest(String accession) {
         return SolrRequest.builder()
-                .query(ACCESSION + ":" + accession)
+                .query(ACCESSION_ID + ":" + accession)
                 .rows(NumberUtils.INTEGER_ONE)
                 .build();
     }
@@ -219,7 +220,7 @@ public class UniProtEntryService
         SolrRequest solrRequest = super.createDownloadSolrRequest(request);
         boolean filterIsoform =
                 UniProtKBRequestUtil.needsToFilterIsoform(
-                        getQueryFieldName(ACCESSION),
+                        getQueryFieldName(ACCESSION_ID),
                         getQueryFieldName("is_isoform"),
                         uniProtRequest.getQuery(),
                         uniProtRequest.isIncludeIsoform());
@@ -245,6 +246,13 @@ public class UniProtEntryService
     @Override
     protected String getSolrIdField() {
         return SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.UNIPROTKB)
+                .getSearchFieldItemByName(ACCESSION_ID)
+                .getFieldName();
+    }
+
+    @Override
+    protected String getTermsQueryField() {
+        return SearchFieldConfigFactory.getSearchFieldConfig(UniProtDataType.UNIPROTKB)
                 .getSearchFieldItemByName(ACCESSION)
                 .getFieldName();
     }
@@ -268,7 +276,7 @@ public class UniProtEntryService
         solrRequest.setQueryConfig(solrQueryConfig);
         boolean filterIsoform =
                 UniProtKBRequestUtil.needsToFilterIsoform(
-                        getQueryFieldName(ACCESSION),
+                        getQueryFieldName(ACCESSION_ID),
                         getQueryFieldName("is_isoform"),
                         solrRequest.getQuery(),
                         uniProtRequest.isIncludeIsoform());

--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBGetByAccessionsIT.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBGetByAccessionsIT.java
@@ -8,10 +8,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.uniprot.api.uniprotkb.controller.UniProtKBEntryConvertITUtils.*;
 
+import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import org.apache.solr.client.solrj.SolrServerException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -122,27 +125,28 @@ class UniProtKBGetByAccessionsIT extends AbstractGetByIdsControllerIT {
             entryBuilder.genesSet(genes);
 
             UniProtKBEntry uniProtKBEntry = entryBuilder.build();
-
-            UniProtDocument document = documentConverter.convert(uniProtKBEntry);
-            document =
-                    UniProtKBEntryConvertITUtils.aggregateTaxonomyDataToDocument(
-                            taxonomyRepo, document);
-
-            cloudSolrClient.addBean(SolrCollection.uniprot.name(), document);
-            storeClient.saveEntry(uniProtKBEntry);
+            saveEntry(uniProtKBEntry);
             prefix--;
         }
         UniProtKBEntry uniProtKBEntry =
                 UniProtKBEntryBuilder.from(UniProtEntryMocker.create(UniProtEntryMocker.Type.TR))
                         .build();
-        UniProtDocument document = documentConverter.convert(uniProtKBEntry);
-        document =
-                UniProtKBEntryConvertITUtils.aggregateTaxonomyDataToDocument(
-                        taxonomyRepo, document);
-        cloudSolrClient.addBean(SolrCollection.uniprot.name(), document);
-        storeClient.saveEntry(uniProtKBEntry);
+        saveEntry(uniProtKBEntry);
+
+        uniProtKBEntry =
+                UniProtKBEntryBuilder.from(UniProtEntryMocker.create(UniProtEntryMocker.Type.SP_ISOFORM))
+                        .build();
+        saveEntry(uniProtKBEntry);
 
         cloudSolrClient.commit(SolrCollection.uniprot.name());
+    }
+
+    private void saveEntry(UniProtKBEntry uniProtKBEntry) throws IOException, SolrServerException {
+        UniProtDocument document = documentConverter.convert(uniProtKBEntry);
+        aggregateTaxonomyDataToDocument(taxonomyRepo, document);
+
+        cloudSolrClient.addBean(SolrCollection.uniprot.name(), document);
+        storeClient.saveEntry(uniProtKBEntry);
     }
 
     @Test
@@ -169,6 +173,28 @@ class UniProtKBGetByAccessionsIT extends AbstractGetByIdsControllerIT {
     }
 
     @Test
+    void getByIdsIsoformEntriesSuccess() throws Exception {
+        // when
+        ResultActions response =
+                getMockMvc()
+                        .perform(
+                                get(getGetByIdsPath())
+                                        .header(
+                                                org.apache.http.HttpHeaders.ACCEPT,
+                                                MediaType.APPLICATION_JSON)
+                                        .param(getRequestParamName(), "p21802-2,p00003")
+                                        .param("size", "10"));
+
+        // then
+        response.andDo(log())
+                .andExpect(status().is(HttpStatus.OK.value()))
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON_VALUE))
+                .andExpect(jsonPath("$.results.size()", is(2)))
+                .andExpect(jsonPath("$.results.*.primaryAccession", contains("P00003", "P21802-2")))
+                .andExpect(jsonPath("$.facets").doesNotExist());
+    }
+
+    @Test
     @Tag("TRM-28917")
     void getByIdsCanonicalIsoformForTremblEntriesSuccess() throws Exception {
         // when
@@ -186,8 +212,8 @@ class UniProtKBGetByAccessionsIT extends AbstractGetByIdsControllerIT {
         response.andDo(log())
                 .andExpect(status().is(HttpStatus.OK.value()))
                 .andExpect(header().string(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON_VALUE))
-                .andExpect(jsonPath("$.results[0].primaryAccession", is("F1Q0X3")))
                 .andExpect(jsonPath("$.results.size()", is(1)))
+                .andExpect(jsonPath("$.results[0].primaryAccession", is("F1Q0X3")))
                 .andExpect(jsonPath("$.facets").doesNotExist());
     }
 


### PR DESCRIPTION
Accessions endpoint not returning data when using entries with only one canonical isoform