### PR TITLE
TRM-29103: idMapping for deleted UniProtKB entries does not show status

### DIFF
--- a/common-rest/src/test/java/org/uniprot/api/rest/output/converter/JsonMessageConverterTest.java
+++ b/common-rest/src/test/java/org/uniprot/api/rest/output/converter/JsonMessageConverterTest.java
@@ -285,7 +285,8 @@ class JsonMessageConverterTest {
         String result = outputStream.toString("UTF-8");
         log.debug(result);
         assertEquals(
-                "{\"results\":[{\"primaryAccession\":\"P00001\"},\n{\"primaryAccession\":\"P00001\"}]}",
+                "{\"results\":[{\"entryType\":\"UniProtKB reviewed (Swiss-Prot)\",\"primaryAccession\":\"P00001\"},\n"
+                        + "{\"entryType\":\"UniProtKB reviewed (Swiss-Prot)\",\"primaryAccession\":\"P00001\"}]}",
                 result);
     }
 
@@ -307,7 +308,7 @@ class JsonMessageConverterTest {
         String result = outputStream.toString("UTF-8");
         log.debug(result);
         assertEquals(
-                "{\"results\":[{\"primaryAccession\":\"P00001\"}],\"failedIds\":[\"id1\"]}",
+                "{\"results\":[{\"entryType\":\"UniProtKB reviewed (Swiss-Prot)\",\"primaryAccession\":\"P00001\"}],\"failedIds\":[\"id1\"]}",
                 result);
     }
 

--- a/idmapping-rest/src/main/java/org/uniprot/api/idmapping/service/impl/UniProtKBIdService.java
+++ b/idmapping-rest/src/main/java/org/uniprot/api/idmapping/service/impl/UniProtKBIdService.java
@@ -153,6 +153,7 @@ public class UniProtKBIdService extends BasicIdService<UniProtKBEntry, UniProtKB
                         storeClient,
                         storeFetchRetryPolicy,
                         lineageService,
+                        repository,
                         isLineageAllowed(fields));
         return StreamSupport.stream(batchIterable.spliterator(), false).flatMap(Collection::stream);
     }

--- a/idmapping-rest/src/main/java/org/uniprot/api/idmapping/service/store/BatchStoreEntryPairIterable.java
+++ b/idmapping-rest/src/main/java/org/uniprot/api/idmapping/service/store/BatchStoreEntryPairIterable.java
@@ -79,8 +79,8 @@ public abstract class BatchStoreEntryPairIterable<T extends EntryPair<S>, S>
 
         // id mapping pairs -> Ts
         return batch.stream()
-                .filter(mId -> idEntryMap.containsKey(mId.getTo()))
                 .map(mId -> convertToPair(mId, idEntryMap))
+                .filter(pair -> pair.getTo() != null)
                 .collect(Collectors.toList());
     }
 

--- a/idmapping-rest/src/main/java/org/uniprot/api/idmapping/service/store/impl/UniParcBatchStoreEntryPairIterable.java
+++ b/idmapping-rest/src/main/java/org/uniprot/api/idmapping/service/store/impl/UniParcBatchStoreEntryPairIterable.java
@@ -32,7 +32,7 @@ public class UniParcBatchStoreEntryPairIterable
             IdMappingStringPair mId, Map<String, UniParcEntry> idEntryMap) {
         return UniParcEntryPair.builder()
                 .from(mId.getFrom())
-                .to(idEntryMap.get(mId.getTo()))
+                .to(idEntryMap.getOrDefault(mId.getTo(), null))
                 .build();
     }
 

--- a/idmapping-rest/src/main/java/org/uniprot/api/idmapping/service/store/impl/UniProtKBBatchStoreEntryPairIterable.java
+++ b/idmapping-rest/src/main/java/org/uniprot/api/idmapping/service/store/impl/UniProtKBBatchStoreEntryPairIterable.java
@@ -12,6 +12,7 @@ import net.jodah.failsafe.RetryPolicy;
 import org.uniprot.api.common.repository.stream.store.uniprotkb.TaxonomyLineageService;
 import org.uniprot.api.idmapping.model.IdMappingStringPair;
 import org.uniprot.api.idmapping.model.UniProtKBEntryPair;
+import org.uniprot.api.idmapping.repository.UniprotKBMappingRepository;
 import org.uniprot.api.idmapping.service.store.BatchStoreEntryPairIterable;
 import org.uniprot.core.uniprotkb.UniProtKBEntry;
 import org.uniprot.store.datastore.UniProtStoreClient;
@@ -25,6 +26,7 @@ public class UniProtKBBatchStoreEntryPairIterable
         extends BatchStoreEntryPairIterable<UniProtKBEntryPair, UniProtKBEntry> {
 
     private final TaxonomyLineageService taxonomyLineageService;
+    private final UniprotKBMappingRepository uniprotKBMappingRepository;
     private final boolean addLineage;
 
     public UniProtKBBatchStoreEntryPairIterable(
@@ -33,10 +35,12 @@ public class UniProtKBBatchStoreEntryPairIterable
             UniProtStoreClient<UniProtKBEntry> storeClient,
             RetryPolicy<Object> retryPolicy,
             TaxonomyLineageService taxonomyLineageService,
+            UniprotKBMappingRepository uniprotKBMappingRepository,
             boolean addLineage) {
         super(sourceIterable, batchSize, storeClient, retryPolicy);
         this.addLineage = addLineage;
         this.taxonomyLineageService = taxonomyLineageService;
+        this.uniprotKBMappingRepository = uniprotKBMappingRepository;
     }
 
     @Override
@@ -44,7 +48,9 @@ public class UniProtKBBatchStoreEntryPairIterable
             IdMappingStringPair mId, Map<String, UniProtKBEntry> idEntryMap) {
         return UniProtKBEntryPair.builder()
                 .from(mId.getFrom())
-                .to(idEntryMap.get(mId.getTo()))
+                .to(
+                        idEntryMap.computeIfAbsent(
+                                mId.getTo(), uniprotKBMappingRepository::getDeletedEntry))
                 .build();
     }
 

--- a/idmapping-rest/src/main/java/org/uniprot/api/idmapping/service/store/impl/UniRefBatchStoreEntryPairIterable.java
+++ b/idmapping-rest/src/main/java/org/uniprot/api/idmapping/service/store/impl/UniRefBatchStoreEntryPairIterable.java
@@ -32,7 +32,7 @@ public class UniRefBatchStoreEntryPairIterable
             IdMappingStringPair mId, Map<String, UniRefEntryLight> idEntryMap) {
         return UniRefEntryPair.builder()
                 .from(mId.getFrom())
-                .to(idEntryMap.get(mId.getTo()))
+                .to(idEntryMap.getOrDefault(mId.getTo(), null))
                 .build();
     }
 

--- a/idmapping-rest/src/test/java/org/uniprot/api/idmapping/controller/AbstractIdMappingBasicControllerIT.java
+++ b/idmapping-rest/src/test/java/org/uniprot/api/idmapping/controller/AbstractIdMappingBasicControllerIT.java
@@ -380,7 +380,7 @@ abstract class AbstractIdMappingBasicControllerIT extends AbstractStreamControll
         assertThat(name, notNullValue());
         assertThat(paths, notNullValue());
         // when
-        IdMappingJob job = getJobOperation().createAndPutJobInCache();
+        IdMappingJob job = getJobOperation().createAndPutJobInCacheForAllFields();
         ResultActions response =
                 performRequest(
                         get(getIdMappingResultPath(), job.getJobId())

--- a/idmapping-rest/src/test/java/org/uniprot/api/idmapping/controller/UniProtKBIdMappingStreamControllerIT.java
+++ b/idmapping-rest/src/test/java/org/uniprot/api/idmapping/controller/UniProtKBIdMappingStreamControllerIT.java
@@ -7,7 +7,6 @@ import static org.springframework.http.HttpHeaders.ACCEPT;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.uniprot.api.idmapping.controller.utils.IdMappingUniProtKBITUtils.*;
 import static org.uniprot.api.rest.output.UniProtMediaType.FASTA_MEDIA_TYPE_VALUE;
@@ -394,7 +393,7 @@ class UniProtKBIdMappingStreamControllerIT extends AbstractIdMappingStreamContro
                                 .param("fields", "accession")
                                 .header(ACCEPT, APPLICATION_JSON_VALUE));
         // then
-        response.andDo(print())
+        response.andDo(log())
                 .andExpect(status().is(HttpStatus.OK.value()))
                 .andExpect(header().string(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$.results.size()", Matchers.is(2)))

--- a/idmapping-rest/src/test/java/org/uniprot/api/idmapping/controller/utils/AbstractJobOperation.java
+++ b/idmapping-rest/src/test/java/org/uniprot/api/idmapping/controller/utils/AbstractJobOperation.java
@@ -19,7 +19,7 @@ import org.uniprot.api.rest.request.idmapping.IdMappingJobRequest;
  */
 public abstract class AbstractJobOperation implements JobOperation {
     public static final int DEFAULT_IDS_COUNT = 20; // same as id.mapping.max.from.ids.count
-    private IdMappingJobCacheService cacheService;
+    private final IdMappingJobCacheService cacheService;
 
     public AbstractJobOperation(IdMappingJobCacheService cacheService) {
         this.cacheService = cacheService;
@@ -27,6 +27,11 @@ public abstract class AbstractJobOperation implements JobOperation {
 
     public IdMappingJobCacheService getIdMappingJobCacheService() {
         return this.cacheService;
+    }
+
+    @Override
+    public IdMappingJob createAndPutJobInCacheForAllFields() throws Exception {
+        return createAndPutJobInCache();
     }
 
     public IdMappingJob createAndPutJobInCache(String from, String to, String fromIds)
@@ -75,7 +80,7 @@ public abstract class AbstractJobOperation implements JobOperation {
             throws InvalidKeySpecException, NoSuchAlgorithmException {
         String fromIds = String.join(",", mappedIds.keySet());
         IdMappingJobRequest idMappingRequest = createRequest(from, to, fromIds);
-        String jobId = generateHash(idMappingRequest);
+        String jobId = generateHash();
         IdMappingResult idMappingResult = createIdMappingResult(idMappingRequest, mappedIds);
         IdMappingJob job = createJob(jobId, idMappingRequest, idMappingResult, jobStatus);
         if (!this.cacheService.exists(jobId)) {
@@ -92,7 +97,7 @@ public abstract class AbstractJobOperation implements JobOperation {
         return request;
     }
 
-    private String generateHash(IdMappingJobRequest request) {
+    private String generateHash() {
         return UUID.randomUUID().toString();
     }
 

--- a/idmapping-rest/src/test/java/org/uniprot/api/idmapping/controller/utils/IdMappingUniProtKBITUtils.java
+++ b/idmapping-rest/src/test/java/org/uniprot/api/idmapping/controller/utils/IdMappingUniProtKBITUtils.java
@@ -8,6 +8,7 @@ import java.util.stream.Stream;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.uniprot.core.cv.xdb.UniProtDatabaseDetail;
 import org.uniprot.core.gene.Gene;
 import org.uniprot.core.json.parser.taxonomy.TaxonomyJsonConfig;
@@ -108,6 +109,18 @@ public class IdMappingUniProtKBITUtils {
             }
         }
         return value;
+    }
+
+    public static void saveInactiveEntry(CloudSolrClient cloudSolrClient)
+            throws IOException, SolrServerException {
+        UniProtDocument inactiveDoc = new UniProtDocument();
+        inactiveDoc.accession = "I8FBX0";
+        inactiveDoc.id = "INACTIVE_DROME";
+        inactiveDoc.idInactive = "INACTIVE_DROME";
+        inactiveDoc.inactiveReason = "DELETED";
+        inactiveDoc.active = false;
+        cloudSolrClient.addBean(SolrCollection.uniprot.name(), inactiveDoc);
+        cloudSolrClient.commit(SolrCollection.uniprot.name());
     }
 
     public static void saveEntry(

--- a/idmapping-rest/src/test/java/org/uniprot/api/idmapping/controller/utils/JobOperation.java
+++ b/idmapping-rest/src/test/java/org/uniprot/api/idmapping/controller/utils/JobOperation.java
@@ -14,6 +14,8 @@ import org.uniprot.api.rest.download.model.JobStatus;
 public interface JobOperation {
     IdMappingJob createAndPutJobInCache() throws Exception;
 
+    IdMappingJob createAndPutJobInCacheForAllFields() throws Exception;
+
     IdMappingJob createAndPutJobInCache(int idsCount) throws Exception;
 
     IdMappingJob createAndPutJobInCache(JobStatus jobStatus) throws Exception;

--- a/idmapping-rest/src/test/java/org/uniprot/api/idmapping/controller/utils/UniProtKBIdMappingResultsJobOperation.java
+++ b/idmapping-rest/src/test/java/org/uniprot/api/idmapping/controller/utils/UniProtKBIdMappingResultsJobOperation.java
@@ -20,17 +20,21 @@ public class UniProtKBIdMappingResultsJobOperation extends AbstractJobOperation 
     }
 
     @Override
+    public IdMappingJob createAndPutJobInCacheForAllFields() throws Exception {
+        Map<String, String> ids = new LinkedHashMap<>();
+        ids.put("I8FBX0", "I8FBX0");
+        ids.putAll(getActiveIdsInMap(DEFAULT_IDS_COUNT - 1));
+        return createAndPutJobInCache(UNIPROTKB_AC_ID_STR, UNIPROTKB_STR, ids, JobStatus.FINISHED);
+    }
+
+    @Override
     public IdMappingJob createAndPutJobInCache(int idsCount) throws Exception {
         return createAndPutJobInCache(idsCount, JobStatus.FINISHED);
     }
 
     @Override
     public IdMappingJob createAndPutJobInCache(int idsCount, JobStatus jobStatus) throws Exception {
-        Map<String, String> ids = new LinkedHashMap<>();
-        for (int i = 1; i <= idsCount; i++) {
-            String id = String.format("Q%05d", i);
-            ids.put(id, id);
-        }
+        Map<String, String> ids = getActiveIdsInMap(idsCount);
         return createAndPutJobInCache(UNIPROTKB_AC_ID_STR, UNIPROTKB_STR, ids, jobStatus);
     }
 
@@ -45,5 +49,14 @@ public class UniProtKBIdMappingResultsJobOperation extends AbstractJobOperation 
             ids.put(fromId, toId);
         }
         return createAndPutJobInCache(UNIPROTKB_AC_ID_STR, UNIPROTKB_STR, ids, jobStatus);
+    }
+
+    private Map<String, String> getActiveIdsInMap(int idsCount) {
+        Map<String, String> ids = new LinkedHashMap<>();
+        for (int i = 1; i <= idsCount; i++) {
+            String id = String.format("Q%05d", i);
+            ids.put(id, id);
+        }
+        return ids;
     }
 }

--- a/idmapping-rest/src/test/java/org/uniprot/api/idmapping/service/store/BatchStoreEntryPairIterableTest.java
+++ b/idmapping-rest/src/test/java/org/uniprot/api/idmapping/service/store/BatchStoreEntryPairIterableTest.java
@@ -93,7 +93,8 @@ class BatchStoreEntryPairIterableTest {
     @Test
     void testLoggingUniProtKB() {
         BatchStoreEntryPairIterable<UniProtKBEntryPair, UniProtKBEntry> iterable =
-                new UniProtKBBatchStoreEntryPairIterable(List.of(), 10, null, null, null, false);
+                new UniProtKBBatchStoreEntryPairIterable(
+                        List.of(), 10, null, null, null, null, false);
         iterable.logTiming(1, 2, 3);
         assertNotNull(iterable);
     }

--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBSearchControllerIT.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBSearchControllerIT.java
@@ -923,7 +923,9 @@ class UniProtKBSearchControllerIT extends AbstractSearchWithSuggestionsControlle
         ResultActions response =
                 getMockMvc()
                         .perform(
-                                get(SEARCH_RESOURCE + "?query=accession:I8FBX2")
+                                get(SEARCH_RESOURCE)
+                                        .param("query", "accession:I8FBX2")
+                                        .param("fields", "accession")
                                         .header(ACCEPT, APPLICATION_JSON_VALUE));
 
         response.andDo(log())
@@ -1493,7 +1495,7 @@ class UniProtKBSearchControllerIT extends AbstractSearchWithSuggestionsControlle
         ResultActions response =
                 getMockMvc()
                         .perform(
-                                get(SEARCH_RESOURCE + "?query=*&fields=accession,xref_dbsnp")
+                                get(SEARCH_RESOURCE + "?query=*&fields=xref_dbsnp")
                                         .header(ACCEPT, APPLICATION_JSON_VALUE));
 
         // then
@@ -1650,6 +1652,11 @@ class UniProtKBSearchControllerIT extends AbstractSearchWithSuggestionsControlle
     }
 
     @Override
+    protected String getAllReturnedFieldsQuery() {
+        return "id:*";
+    }
+
+    @Override
     protected void saveEntry(SaveScenario saveContext) {
         UniProtEntryConverter converter = new UniProtEntryConverter(new HashMap<>());
         UniProtKBEntry entry =
@@ -1674,8 +1681,15 @@ class UniProtKBSearchControllerIT extends AbstractSearchWithSuggestionsControlle
         if (SaveScenario.SEARCH_ALL_FIELDS.equals(saveContext)
                 || SaveScenario.SEARCH_ALL_RETURN_FIELDS.equals(saveContext)
                 || SaveScenario.FACETS_SUCCESS.equals(saveContext)) {
+
+            InactiveUniProtEntry inactiveDrome =
+                    InactiveUniProtEntry.from("I8FBX0", "INACTIVE_DROME", DELETED, null);
+            getStoreManager()
+                    .saveEntriesInSolr(DataStoreManager.StoreType.INACTIVE_UNIPROT, inactiveDrome);
+
             UniProtDocument doc = new UniProtDocument();
             doc.accession = "P00001";
+            doc.id = "Search All";
             doc.active = true;
             doc.fragment = true;
             doc.precursor = true;


### PR DESCRIPTION
idMapping for deleted UniProtKB entries does not return inactiveStatus