### PR TITLE
avoid voldemort for list format in search and stream api calls

### DIFF
--- a/aa-rest/src/main/java/org/uniprot/api/aa/request/ArbaBasicRequest.java
+++ b/aa-rest/src/main/java/org/uniprot/api/aa/request/ArbaBasicRequest.java
@@ -39,5 +39,6 @@ public class ArbaBasicRequest {
     @ValidReturnFields(uniProtDataType = UniProtDataType.ARBA)
     private String fields;
 
+    @Parameter(hidden = true)
     private String format;
 }

--- a/aa-rest/src/main/java/org/uniprot/api/aa/request/ArbaBasicRequest.java
+++ b/aa-rest/src/main/java/org/uniprot/api/aa/request/ArbaBasicRequest.java
@@ -38,4 +38,6 @@ public class ArbaBasicRequest {
     @Parameter(description = "Comma separated list of fields to be returned in response")
     @ValidReturnFields(uniProtDataType = UniProtDataType.ARBA)
     private String fields;
+
+    private String format;
 }

--- a/aa-rest/src/main/java/org/uniprot/api/aa/request/UniRuleBasicRequest.java
+++ b/aa-rest/src/main/java/org/uniprot/api/aa/request/UniRuleBasicRequest.java
@@ -40,4 +40,6 @@ public class UniRuleBasicRequest {
     @Parameter(description = "Comma separated list of fields to be returned in response")
     @ValidReturnFields(uniProtDataType = UniProtDataType.UNIRULE)
     private String fields;
+
+    private String format;
 }

--- a/aa-rest/src/main/java/org/uniprot/api/aa/request/UniRuleBasicRequest.java
+++ b/aa-rest/src/main/java/org/uniprot/api/aa/request/UniRuleBasicRequest.java
@@ -41,5 +41,6 @@ public class UniRuleBasicRequest {
     @ValidReturnFields(uniProtDataType = UniProtDataType.UNIRULE)
     private String fields;
 
+    @Parameter(hidden = true)
     private String format;
 }

--- a/common-rest/src/main/java/org/uniprot/api/common/repository/stream/store/uniprotkb/TaxonomyLineageServiceImpl.java
+++ b/common-rest/src/main/java/org/uniprot/api/common/repository/stream/store/uniprotkb/TaxonomyLineageServiceImpl.java
@@ -112,6 +112,7 @@ public class TaxonomyLineageServiceImpl extends BasicSearchService<TaxonomyDocum
     static class TaxonomyLineageStreamRequest implements StreamRequest {
 
         private final String query;
+        private String format;
 
         TaxonomyLineageStreamRequest(String query) {
             this.query = query;
@@ -130,6 +131,16 @@ public class TaxonomyLineageServiceImpl extends BasicSearchService<TaxonomyDocum
         @Override
         public String getSort() {
             return null;
+        }
+
+        @Override
+        public String getFormat() {
+            return null;
+        }
+
+        @Override
+        public void setFormat(String format) {
+            this.format = format;
         }
 
         @Override

--- a/common-rest/src/main/java/org/uniprot/api/rest/controller/BasicSearchController.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/controller/BasicSearchController.java
@@ -28,6 +28,7 @@ import org.uniprot.api.rest.output.context.FileType;
 import org.uniprot.api.rest.output.context.MessageConverterContext;
 import org.uniprot.api.rest.output.context.MessageConverterContextFactory;
 import org.uniprot.api.rest.pagination.PaginatedResultsEvent;
+import org.uniprot.api.rest.request.BasicRequest;
 import org.uniprot.api.rest.request.StreamRequest;
 import org.uniprot.core.util.Utils;
 
@@ -163,7 +164,8 @@ public abstract class BasicSearchController<T> {
             headers = createHttpDownloadHeader(context, request);
         }
 
-        ApplicationEvent paginatedResultEvent = new PaginatedResultsEvent(this, request, response, result.getPageAndClean());
+        ApplicationEvent paginatedResultEvent =
+                new PaginatedResultsEvent(this, request, response, result.getPageAndClean());
         publishPaginationEvent(paginatedResultEvent);
         return ResponseEntity.ok().headers(headers).body(context);
     }
@@ -283,6 +285,11 @@ public abstract class BasicSearchController<T> {
             return Optional.of(SUPPORTED_RDF_MEDIA_TYPES.get(contentType));
         }
         return Optional.empty();
+    }
+
+    protected void setBasicRequestFormat(BasicRequest basicRequest, HttpServletRequest request) {
+        MediaType mediaType = getAcceptHeader(request);
+        basicRequest.setFormat(mediaType.toString());
     }
 
     protected MessageConverterContext<T> createStreamContext(

--- a/common-rest/src/main/java/org/uniprot/api/rest/request/BasicRequest.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/request/BasicRequest.java
@@ -14,6 +14,10 @@ public interface BasicRequest {
 
     String getSort();
 
+    String getFormat();
+
+    void setFormat(String format);
+
     default boolean hasFields() {
         return Utils.notNullNotEmpty(getFields());
     }

--- a/common-rest/src/main/java/org/uniprot/api/rest/service/BasicSearchService.java
+++ b/common-rest/src/main/java/org/uniprot/api/rest/service/BasicSearchService.java
@@ -1,6 +1,7 @@
 package org.uniprot.api.rest.service;
 
 import static org.uniprot.api.rest.output.PredefinedAPIStatus.LEADING_WILDCARD_IGNORED;
+import static org.uniprot.api.rest.output.UniProtMediaType.LIST_MEDIA_TYPE_VALUE;
 
 import java.util.List;
 import java.util.Objects;
@@ -102,7 +103,17 @@ public abstract class BasicSearchService<D extends Document, R> {
     public QueryResult<R> search(SearchRequest request) {
         SolrRequest solrRequest = createSearchSolrRequest(request);
         QueryResult<D> results = repository.searchPage(solrRequest, request.getCursor());
-        Stream<R> converted = results.getContent().map(entryConverter).filter(Objects::nonNull);
+        Stream<R> converted;
+        if (LIST_MEDIA_TYPE_VALUE.equals(request.getFormat())) {
+            converted =
+                    results.getContent()
+                            .map(Document::getDocumentId)
+                            .map(this::mapToThinEntry)
+                            .filter(Objects::nonNull);
+        } else {
+            converted = results.getContent().map(entryConverter).filter(Objects::nonNull);
+        }
+
         Set<ProblemPair> warnings = getWarnings(request.getQuery(), Set.of());
         return QueryResult.of(
                 converted,
@@ -264,6 +275,10 @@ public abstract class BasicSearchService<D extends Document, R> {
         ProblemPair warning = getLeadingWildcardIgnoredWarning(query, leadWildcardSupportedFields);
         Set<ProblemPair> warnings = Objects.isNull(warning) ? null : Set.of(warning);
         return warnings;
+    }
+
+    protected R mapToThinEntry(String entryId) {
+        throw new UnsupportedOperationException("Override this method");
     }
 
     private ProblemPair getLeadingWildcardIgnoredWarning(

--- a/common-rest/src/test/java/org/uniprot/api/rest/service/BasicSearchServiceTest.java
+++ b/common-rest/src/test/java/org/uniprot/api/rest/service/BasicSearchServiceTest.java
@@ -395,5 +395,7 @@ class BasicSearchServiceTest {
         private String query;
         private String fields;
         private String sort;
+
+        private String format;
     }
 }

--- a/common-rest/src/test/java/org/uniprot/api/rest/validation/FakeIdsPostRequest.java
+++ b/common-rest/src/test/java/org/uniprot/api/rest/validation/FakeIdsPostRequest.java
@@ -30,6 +30,14 @@ public class FakeIdsPostRequest implements IdsSearchRequest {
     }
 
     @Override
+    public String getFormat() {
+        return null;
+    }
+
+    @Override
+    public void setFormat(String format) {}
+
+    @Override
     public void setCursor(String cursor) {
         // do nothing
     }

--- a/help-centre-rest/src/main/java/org/uniprot/api/help/centre/request/HelpCentreSearchRequest.java
+++ b/help-centre-rest/src/main/java/org/uniprot/api/help/centre/request/HelpCentreSearchRequest.java
@@ -71,6 +71,7 @@ public class HelpCentreSearchRequest implements SearchRequest {
     @Parameter(hidden = true)
     private String type;
 
+    @Parameter(hidden = true)
     private String format;
 
     public String getFields() {

--- a/help-centre-rest/src/main/java/org/uniprot/api/help/centre/request/HelpCentreSearchRequest.java
+++ b/help-centre-rest/src/main/java/org/uniprot/api/help/centre/request/HelpCentreSearchRequest.java
@@ -71,6 +71,8 @@ public class HelpCentreSearchRequest implements SearchRequest {
     @Parameter(hidden = true)
     private String type;
 
+    private String format;
+
     public String getFields() {
         String result = fields;
         if (Utils.nullOrEmpty(result)) {

--- a/idmapping-rest/src/main/java/org/uniprot/api/idmapping/controller/request/IdMappingStreamRequest.java
+++ b/idmapping-rest/src/main/java/org/uniprot/api/idmapping/controller/request/IdMappingStreamRequest.java
@@ -29,4 +29,5 @@ public class IdMappingStreamRequest implements StreamRequest {
     private String query;
     private String fields;
     private String sort;
+    private String format;
 }

--- a/idmapping-rest/src/main/java/org/uniprot/api/idmapping/controller/request/uniparc/UniParcIdMappingBasicRequest.java
+++ b/idmapping-rest/src/main/java/org/uniprot/api/idmapping/controller/request/uniparc/UniParcIdMappingBasicRequest.java
@@ -41,4 +41,6 @@ public class UniParcIdMappingBasicRequest extends IdMappingPageRequest {
     @Parameter(description = "Name of the field to be sorted on")
     @ValidSolrSortFields(uniProtDataType = UniProtDataType.UNIPARC)
     private String sort;
+
+    private String format;
 }

--- a/idmapping-rest/src/main/java/org/uniprot/api/idmapping/controller/request/uniparc/UniParcIdMappingBasicRequest.java
+++ b/idmapping-rest/src/main/java/org/uniprot/api/idmapping/controller/request/uniparc/UniParcIdMappingBasicRequest.java
@@ -42,5 +42,6 @@ public class UniParcIdMappingBasicRequest extends IdMappingPageRequest {
     @ValidSolrSortFields(uniProtDataType = UniProtDataType.UNIPARC)
     private String sort;
 
+    @Parameter(hidden = true)
     private String format;
 }

--- a/idmapping-rest/src/main/java/org/uniprot/api/idmapping/controller/request/uniprotkb/UniProtKBIdMappingBasicRequest.java
+++ b/idmapping-rest/src/main/java/org/uniprot/api/idmapping/controller/request/uniprotkb/UniProtKBIdMappingBasicRequest.java
@@ -59,6 +59,8 @@ public class UniProtKBIdMappingBasicRequest extends IdMappingPageRequest {
             message = "{search.invalid.contentType.subsequence}")
     private String subsequence;
 
+    private String format;
+
     public boolean isSubSequence() {
         return Boolean.parseBoolean(subsequence);
     }

--- a/idmapping-rest/src/main/java/org/uniprot/api/idmapping/controller/request/uniprotkb/UniProtKBIdMappingBasicRequest.java
+++ b/idmapping-rest/src/main/java/org/uniprot/api/idmapping/controller/request/uniprotkb/UniProtKBIdMappingBasicRequest.java
@@ -59,6 +59,7 @@ public class UniProtKBIdMappingBasicRequest extends IdMappingPageRequest {
             message = "{search.invalid.contentType.subsequence}")
     private String subsequence;
 
+    @Parameter(hidden = true)
     private String format;
 
     public boolean isSubSequence() {

--- a/idmapping-rest/src/main/java/org/uniprot/api/idmapping/controller/request/uniref/UniRefIdMappingBasicRequest.java
+++ b/idmapping-rest/src/main/java/org/uniprot/api/idmapping/controller/request/uniref/UniRefIdMappingBasicRequest.java
@@ -39,5 +39,6 @@ public class UniRefIdMappingBasicRequest extends IdMappingPageRequest {
     @ValidSolrSortFields(uniProtDataType = UniProtDataType.UNIREF)
     private String sort;
 
+    @Parameter(hidden = true)
     private String format;
 }

--- a/idmapping-rest/src/main/java/org/uniprot/api/idmapping/controller/request/uniref/UniRefIdMappingBasicRequest.java
+++ b/idmapping-rest/src/main/java/org/uniprot/api/idmapping/controller/request/uniref/UniRefIdMappingBasicRequest.java
@@ -38,4 +38,6 @@ public class UniRefIdMappingBasicRequest extends IdMappingPageRequest {
     @Parameter(description = "Name of the field to be sorted on")
     @ValidSolrSortFields(uniProtDataType = UniProtDataType.UNIREF)
     private String sort;
+
+    private String format;
 }

--- a/idmapping-rest/src/main/java/org/uniprot/api/idmapping/service/BasicIdService.java
+++ b/idmapping-rest/src/main/java/org/uniprot/api/idmapping/service/BasicIdService.java
@@ -379,6 +379,7 @@ public abstract class BasicIdService<T, U> {
         private final String sort;
         private final String fields;
         private Integer size;
+        private String format;
 
         @Override
         public void setSize(Integer size) {
@@ -390,7 +391,13 @@ public abstract class BasicIdService<T, U> {
                     .fields(streamRequest.getFields())
                     .query(streamRequest.getQuery())
                     .sort(streamRequest.getSort())
+                    .format(streamRequest.getFormat())
                     .build();
+        }
+
+        @Override
+        public void setFormat(String format) {
+            // do nothing
         }
     }
 }

--- a/idmapping-rest/src/main/java/org/uniprot/api/idmapping/service/config/IdMappingConfig.java
+++ b/idmapping-rest/src/main/java/org/uniprot/api/idmapping/service/config/IdMappingConfig.java
@@ -3,9 +3,7 @@ package org.uniprot.api.idmapping.service.config;
 import java.io.IOException;
 import java.util.Map;
 
-import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
-import org.redisson.config.Config;
 import org.redisson.spring.cache.CacheConfig;
 import org.redisson.spring.cache.RedissonSpringCacheManager;
 import org.springframework.beans.factory.annotation.Value;

--- a/proteome-rest/src/main/java/org/uniprot/api/proteome/request/GeneCentricBasicRequest.java
+++ b/proteome-rest/src/main/java/org/uniprot/api/proteome/request/GeneCentricBasicRequest.java
@@ -48,5 +48,6 @@ public class GeneCentricBasicRequest {
     @ValidReturnFields(uniProtDataType = UniProtDataType.GENECENTRIC)
     private String fields;
 
+    @Parameter(hidden = true)
     private String format;
 }

--- a/proteome-rest/src/main/java/org/uniprot/api/proteome/request/GeneCentricBasicRequest.java
+++ b/proteome-rest/src/main/java/org/uniprot/api/proteome/request/GeneCentricBasicRequest.java
@@ -47,4 +47,6 @@ public class GeneCentricBasicRequest {
     @Parameter(description = "Comma separated list of fields to be returned in response")
     @ValidReturnFields(uniProtDataType = UniProtDataType.GENECENTRIC)
     private String fields;
+
+    private String format;
 }

--- a/proteome-rest/src/main/java/org/uniprot/api/proteome/request/ProteomeBasicRequest.java
+++ b/proteome-rest/src/main/java/org/uniprot/api/proteome/request/ProteomeBasicRequest.java
@@ -42,5 +42,6 @@ public class ProteomeBasicRequest {
     @ValidReturnFields(uniProtDataType = UniProtDataType.PROTEOME)
     private String fields;
 
+    @Parameter(hidden = true)
     private String format;
 }

--- a/proteome-rest/src/main/java/org/uniprot/api/proteome/request/ProteomeBasicRequest.java
+++ b/proteome-rest/src/main/java/org/uniprot/api/proteome/request/ProteomeBasicRequest.java
@@ -41,4 +41,6 @@ public class ProteomeBasicRequest {
     @Parameter(description = "Comma separated list of fields to be returned in response")
     @ValidReturnFields(uniProtDataType = UniProtDataType.PROTEOME)
     private String fields;
+
+    private String format;
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/configure/service/UniProtKBConfigureService.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/configure/service/UniProtKBConfigureService.java
@@ -152,8 +152,8 @@ public class UniProtKBConfigureService {
         return builder.build();
     }
 
-    boolean filteredUniProtDBCategory(UniProtDatabaseCategory dbCategory){
-        return dbCategory != UniProtDatabaseCategory.UNKNOWN &&
-          dbCategory != UniProtDatabaseCategory.GENE_ONTOLOGY_DATABASES;
+    boolean filteredUniProtDBCategory(UniProtDatabaseCategory dbCategory) {
+        return dbCategory != UniProtDatabaseCategory.UNKNOWN
+                && dbCategory != UniProtDatabaseCategory.GENE_ONTOLOGY_DATABASES;
     }
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/crossref/request/CrossRefBasicRequest.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/crossref/request/CrossRefBasicRequest.java
@@ -42,4 +42,6 @@ public class CrossRefBasicRequest {
     @Parameter(description = "Comma separated list of fields to be returned in response")
     @ValidReturnFields(uniProtDataType = UniProtDataType.CROSSREF)
     private String fields;
+
+    private String format;
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/crossref/request/CrossRefBasicRequest.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/crossref/request/CrossRefBasicRequest.java
@@ -43,5 +43,6 @@ public class CrossRefBasicRequest {
     @ValidReturnFields(uniProtDataType = UniProtDataType.CROSSREF)
     private String fields;
 
+    @Parameter(hidden = true)
     private String format;
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/disease/request/DiseaseBasicRequest.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/disease/request/DiseaseBasicRequest.java
@@ -41,5 +41,6 @@ public class DiseaseBasicRequest {
     @ValidReturnFields(uniProtDataType = UniProtDataType.DISEASE)
     private String fields;
 
+    @Parameter(hidden = true)
     private String format;
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/disease/request/DiseaseBasicRequest.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/disease/request/DiseaseBasicRequest.java
@@ -40,4 +40,6 @@ public class DiseaseBasicRequest {
     @Parameter(description = "Comma separated list of fields to be returned in response")
     @ValidReturnFields(uniProtDataType = UniProtDataType.DISEASE)
     private String fields;
+
+    private String format;
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/keyword/request/KeywordBasicRequest.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/keyword/request/KeywordBasicRequest.java
@@ -40,4 +40,6 @@ public class KeywordBasicRequest {
     @Parameter(description = "Comma separated list of fields to be returned in response")
     @ValidReturnFields(uniProtDataType = UniProtDataType.KEYWORD)
     private String fields;
+
+    private String format;
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/keyword/request/KeywordBasicRequest.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/keyword/request/KeywordBasicRequest.java
@@ -41,5 +41,6 @@ public class KeywordBasicRequest {
     @ValidReturnFields(uniProtDataType = UniProtDataType.KEYWORD)
     private String fields;
 
+    @Parameter(hidden = true)
     private String format;
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/literature/request/LiteratureBasicRequest.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/literature/request/LiteratureBasicRequest.java
@@ -45,5 +45,6 @@ public class LiteratureBasicRequest {
     @ValidReturnFields(uniProtDataType = UniProtDataType.LITERATURE)
     private String fields;
 
+    @Parameter(hidden = true)
     private String format;
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/literature/request/LiteratureBasicRequest.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/literature/request/LiteratureBasicRequest.java
@@ -44,4 +44,6 @@ public class LiteratureBasicRequest {
     @Parameter(description = "Comma separated list of fields to be returned in response")
     @ValidReturnFields(uniProtDataType = UniProtDataType.LITERATURE)
     private String fields;
+
+    private String format;
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/subcellular/request/SubcellularLocationBasicRequest.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/subcellular/request/SubcellularLocationBasicRequest.java
@@ -49,5 +49,6 @@ public class SubcellularLocationBasicRequest {
     @ValidReturnFields(uniProtDataType = UniProtDataType.SUBCELLLOCATION)
     private String fields;
 
+    @Parameter(hidden = true)
     private String format;
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/subcellular/request/SubcellularLocationBasicRequest.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/subcellular/request/SubcellularLocationBasicRequest.java
@@ -48,4 +48,6 @@ public class SubcellularLocationBasicRequest {
     @Parameter(description = "Comma separated list of fields to be returned in response")
     @ValidReturnFields(uniProtDataType = UniProtDataType.SUBCELLLOCATION)
     private String fields;
+
+    private String format;
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/taxonomy/request/GetByTaxonIdsRequest.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/taxonomy/request/GetByTaxonIdsRequest.java
@@ -68,6 +68,7 @@ public class GetByTaxonIdsRequest implements SearchRequest {
     @Parameter(hidden = true)
     private String cursor;
 
+    @Parameter(hidden = true)
     private String format;
 
     @Override

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/taxonomy/request/GetByTaxonIdsRequest.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/taxonomy/request/GetByTaxonIdsRequest.java
@@ -68,6 +68,8 @@ public class GetByTaxonIdsRequest implements SearchRequest {
     @Parameter(hidden = true)
     private String cursor;
 
+    private String format;
+
     @Override
     public String getQuery() {
         StringBuilder qb = new StringBuilder();

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/taxonomy/request/TaxonomyBasicRequest.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/taxonomy/request/TaxonomyBasicRequest.java
@@ -40,4 +40,6 @@ public class TaxonomyBasicRequest {
     @Parameter(description = "Comma separated list of fields to be returned in response")
     @ValidReturnFields(uniProtDataType = UniProtDataType.TAXONOMY)
     private String fields;
+
+    private String format;
 }

--- a/support-data-rest/src/main/java/org/uniprot/api/support/data/taxonomy/request/TaxonomyBasicRequest.java
+++ b/support-data-rest/src/main/java/org/uniprot/api/support/data/taxonomy/request/TaxonomyBasicRequest.java
@@ -41,5 +41,6 @@ public class TaxonomyBasicRequest {
     @ValidReturnFields(uniProtDataType = UniProtDataType.TAXONOMY)
     private String fields;
 
+    @Parameter(hidden = true)
     private String format;
 }

--- a/uniparc-rest/src/main/java/org/uniprot/api/uniparc/controller/UniParcController.java
+++ b/uniparc-rest/src/main/java/org/uniprot/api/uniparc/controller/UniParcController.java
@@ -117,6 +117,7 @@ public class UniParcController extends BasicSearchController<UniParcEntry> {
             HttpServletRequest request,
             HttpServletResponse response) {
         setPreviewInfo(searchRequest, preview);
+        setBasicRequestFormat(searchRequest, request);
         QueryResult<UniParcEntry> results = queryService.search(searchRequest);
         return super.getSearchResponse(results, searchRequest.getFields(), request, response);
     }
@@ -215,7 +216,7 @@ public class UniParcController extends BasicSearchController<UniParcEntry> {
                     MediaType contentType,
             @RequestHeader(value = "Accept-Encoding", required = false) String encoding,
             HttpServletRequest request) {
-
+        setBasicRequestFormat(streamRequest, request);
         Optional<String> acceptedRdfContentType = getAcceptedRdfContentType(request);
         if (acceptedRdfContentType.isPresent()) {
             return super.streamRdf(

--- a/uniparc-rest/src/main/java/org/uniprot/api/uniparc/request/UniParcBasicRequest.java
+++ b/uniparc-rest/src/main/java/org/uniprot/api/uniparc/request/UniParcBasicRequest.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import org.uniprot.api.rest.request.QueryFieldMetaReaderImpl;
 import org.uniprot.api.rest.request.ReturnFieldMetaReaderImpl;
 import org.uniprot.api.rest.request.SortFieldMetaReaderImpl;
+import org.uniprot.api.rest.request.UniProtKBRequestUtil;
 import org.uniprot.api.rest.validation.*;
 import org.uniprot.store.config.UniProtDataType;
 
@@ -38,4 +39,11 @@ public class UniParcBasicRequest {
     @Parameter(description = "Comma separated list of fields to be returned in response")
     @ValidReturnFields(uniProtDataType = UniProtDataType.UNIPARC)
     protected String fields;
+
+    @Parameter(hidden = true)
+    private String format;
+
+    public void setFormat(String format) {
+        this.format = UniProtKBRequestUtil.parseFormat(format);
+    }
 }

--- a/uniparc-rest/src/main/java/org/uniprot/api/uniparc/request/UniParcGetByIdRequest.java
+++ b/uniparc-rest/src/main/java/org/uniprot/api/uniparc/request/UniParcGetByIdRequest.java
@@ -25,4 +25,6 @@ public class UniParcGetByIdRequest {
     @Parameter(description = "Comma separated list of taxonomy Ids")
     @ValidCommaSeparatedItemsLength(maxLength = 100)
     private String taxonIds;
+
+    private String format;
 }

--- a/uniparc-rest/src/main/java/org/uniprot/api/uniparc/request/UniParcGetByIdRequest.java
+++ b/uniparc-rest/src/main/java/org/uniprot/api/uniparc/request/UniParcGetByIdRequest.java
@@ -26,5 +26,6 @@ public class UniParcGetByIdRequest {
     @ValidCommaSeparatedItemsLength(maxLength = 100)
     private String taxonIds;
 
+    @Parameter(hidden = true)
     private String format;
 }

--- a/uniparc-rest/src/main/java/org/uniprot/api/uniparc/request/UniParcIdsPostRequest.java
+++ b/uniparc-rest/src/main/java/org/uniprot/api/uniparc/request/UniParcIdsPostRequest.java
@@ -16,6 +16,8 @@ public class UniParcIdsPostRequest extends IdsDownloadRequest {
     private String upis;
     private String fields;
 
+    private String format;
+
     public String getCommaSeparatedIds() {
         return this.upis;
     }

--- a/uniparc-rest/src/main/java/org/uniprot/api/uniparc/request/UniParcIdsSearchRequest.java
+++ b/uniparc-rest/src/main/java/org/uniprot/api/uniparc/request/UniParcIdsSearchRequest.java
@@ -76,6 +76,9 @@ public class UniParcIdsSearchRequest implements IdsSearchRequest {
     @ValidSolrSortFields(uniProtDataType = UniProtDataType.UNIPARC)
     private String sort;
 
+    @Parameter(hidden = true)
+    private String format;
+
     public String getCommaSeparatedIds() {
         return this.upis;
     }

--- a/uniparc-rest/src/test/java/org/uniprot/api/uniparc/service/UniParcQueryServiceTest.java
+++ b/uniparc-rest/src/test/java/org/uniprot/api/uniparc/service/UniParcQueryServiceTest.java
@@ -1,0 +1,178 @@
+package org.uniprot.api.uniparc.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.uniprot.api.rest.output.UniProtMediaType.FASTA_MEDIA_TYPE_VALUE;
+import static org.uniprot.api.rest.output.UniProtMediaType.LIST_MEDIA_TYPE_VALUE;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.uniprot.api.common.repository.search.QueryResult;
+import org.uniprot.api.common.repository.search.SolrQueryConfig;
+import org.uniprot.api.common.repository.search.page.impl.CursorPage;
+import org.uniprot.api.common.repository.solrstream.FacetTupleStreamTemplate;
+import org.uniprot.api.common.repository.stream.document.TupleStreamDocumentIdStream;
+import org.uniprot.api.common.repository.stream.rdf.RdfStreamer;
+import org.uniprot.api.common.repository.stream.store.StoreStreamer;
+import org.uniprot.api.rest.respository.facet.impl.UniParcFacetConfig;
+import org.uniprot.api.rest.service.query.processor.UniProtQueryProcessorConfig;
+import org.uniprot.api.uniparc.repository.UniParcQueryRepository;
+import org.uniprot.api.uniparc.request.UniParcSearchRequest;
+import org.uniprot.api.uniparc.request.UniParcStreamRequest;
+import org.uniprot.core.uniparc.UniParcEntry;
+import org.uniprot.core.uniparc.impl.UniParcEntryBuilder;
+import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
+import org.uniprot.store.search.document.uniparc.UniParcDocument;
+
+/**
+ * @author sahmad
+ * @created 13/06/2023
+ */
+@ExtendWith(MockitoExtension.class)
+class UniParcQueryServiceTest {
+    @Mock private UniParcQueryRepository repository;
+    @Mock private UniParcFacetConfig facetConfig;
+    @Mock private UniParcSortClause solrSortClause;
+    @Mock private UniParcQueryResultConverter uniParcQueryResultConverter;
+    @Mock private StoreStreamer<UniParcEntry> storeStreamer;
+    @Mock private SolrQueryConfig uniParcSolrQueryConf;
+    @Mock private UniProtQueryProcessorConfig uniParcQueryProcessorConfig;
+    @Mock private SearchFieldConfig uniParcSearchFieldConfig;
+    @Mock private RdfStreamer uniparcRdfStreamer;
+    @Mock private FacetTupleStreamTemplate facetTupleStreamTemplate;
+    @Mock private TupleStreamDocumentIdStream solrIdStreamer;
+    private UniParcQueryService service;
+
+    @BeforeEach
+    void init() {
+        service =
+                new UniParcQueryService(
+                        repository,
+                        facetConfig,
+                        solrSortClause,
+                        uniParcQueryResultConverter,
+                        storeStreamer,
+                        uniParcSolrQueryConf,
+                        uniParcQueryProcessorConfig,
+                        uniParcSearchFieldConfig,
+                        uniparcRdfStreamer,
+                        facetTupleStreamTemplate,
+                        solrIdStreamer);
+    }
+
+    @Test
+    void search_in_list_format_without_voldemort_being_called() {
+        // when
+        UniParcDocument doc1 =
+                new UniParcDocument.UniParcDocumentBuilder().upi("UPI0000000001").build();
+        UniParcDocument doc2 =
+                new UniParcDocument.UniParcDocumentBuilder().upi("UPI0000000002").build();
+        QueryResult<UniParcDocument> solrResult =
+                QueryResult.of(Stream.of(doc1, doc2), CursorPage.of("", 10));
+        UniParcSearchRequest searchRequest = new UniParcSearchRequest();
+        searchRequest.setQuery("field:value");
+        searchRequest.setFormat(LIST_MEDIA_TYPE_VALUE);
+        searchRequest.setSize(10);
+        when(repository.searchPage(any(), any())).thenReturn(solrResult);
+        // then
+        QueryResult<UniParcEntry> result = service.search(searchRequest);
+        List<UniParcEntry> entries = result.getContent().collect(Collectors.toList());
+        verify(uniParcQueryResultConverter, never()).apply(any());
+        assertFalse(entries.isEmpty());
+        assertEquals(2, entries.size());
+        List<String> upis =
+                entries.stream()
+                        .map(entry -> entry.getUniParcId().getValue())
+                        .collect(Collectors.toList());
+        assertEquals(List.of("UPI0000000001", "UPI0000000002"), upis);
+    }
+
+    @Test
+    void search_in_non_list_format_with_voldemort_being_called() {
+        // when
+        UniParcDocument doc1 =
+                new UniParcDocument.UniParcDocumentBuilder().upi("UPI0000000001").build();
+        UniParcEntry entry1 = new UniParcEntryBuilder().uniParcId("UPI0000000001").build();
+        UniParcDocument doc2 =
+                new UniParcDocument.UniParcDocumentBuilder().upi("UPI0000000002").build();
+        UniParcEntry entry2 = new UniParcEntryBuilder().uniParcId("UPI0000000002").build();
+        QueryResult<UniParcDocument> solrResult =
+                QueryResult.of(Stream.of(doc1, doc2), CursorPage.of("", 10));
+        UniParcSearchRequest searchRequest = new UniParcSearchRequest();
+        searchRequest.setQuery("field:value");
+        searchRequest.setFormat(APPLICATION_JSON_VALUE);
+        searchRequest.setSize(10);
+        when(repository.searchPage(any(), any())).thenReturn(solrResult);
+        when(uniParcQueryResultConverter.apply(doc1)).thenReturn(entry1);
+        when(uniParcQueryResultConverter.apply(doc2)).thenReturn(entry2);
+        // then
+        QueryResult<UniParcEntry> result = service.search(searchRequest);
+        List<UniParcEntry> entries = result.getContent().collect(Collectors.toList());
+        verify(uniParcQueryResultConverter, times(2)).apply(any());
+        assertFalse(entries.isEmpty());
+        assertEquals(2, entries.size());
+        List<String> upis =
+                entries.stream()
+                        .map(entry -> entry.getUniParcId().getValue())
+                        .collect(Collectors.toList());
+        assertEquals(List.of("UPI0000000001", "UPI0000000002"), upis);
+    }
+
+    @Test
+    void stream_in_list_format_without_voldemort_being_called() {
+        UniParcStreamRequest request = new UniParcStreamRequest();
+        List<String> upis =
+                List.of(
+                        "UPI0000000001",
+                        "UPI0000000002",
+                        "UPI0000000003",
+                        "UPI0000000004",
+                        "UPI0000000005");
+        request.setQuery("field:value");
+        request.setFormat(LIST_MEDIA_TYPE_VALUE);
+        when(solrIdStreamer.fetchIds(any())).thenReturn(upis.stream());
+        Stream<UniParcEntry> result = service.stream(request);
+        List<UniParcEntry> entries = result.collect(Collectors.toList());
+        assertEquals(5, entries.size());
+        assertEquals(
+                upis,
+                entries.stream()
+                        .map(e -> e.getUniParcId().getValue())
+                        .collect(Collectors.toList()));
+        verify(storeStreamer, never()).idsToStoreStream(any());
+    }
+
+    @Test
+    void stream_in_non_list_format_with_voldemort_store_streamer_being_called() {
+        UniParcStreamRequest request = new UniParcStreamRequest();
+        List<String> upis =
+                List.of(
+                        "UPI0000000001",
+                        "UPI0000000002",
+                        "UPI0000000003",
+                        "UPI0000000004",
+                        "UPI0000000005");
+        Stream<UniParcEntry> entriesStream =
+                upis.stream().map(id -> new UniParcEntryBuilder().uniParcId(id).build());
+        request.setQuery("field:value");
+        request.setFormat(FASTA_MEDIA_TYPE_VALUE);
+        when(storeStreamer.idsToStoreStream(any())).thenReturn(entriesStream);
+        Stream<UniParcEntry> result = service.stream(request);
+        List<UniParcEntry> entries = result.collect(Collectors.toList());
+        assertEquals(5, entries.size());
+        assertEquals(
+                upis,
+                entries.stream()
+                        .map(e -> e.getUniParcId().getValue())
+                        .collect(Collectors.toList()));
+        verify(storeStreamer, times(1)).idsToStoreStream(any());
+    }
+}

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/controller/UniProtKBController.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/controller/UniProtKBController.java
@@ -140,6 +140,7 @@ public class UniProtKBController extends BasicSearchController<UniProtKBEntry> {
             HttpServletRequest request,
             HttpServletResponse response) {
         setPreviewInfo(searchRequest, preview);
+        setBasicRequestFormat(searchRequest, request);
         QueryResult<UniProtKBEntry> result = entryService.search(searchRequest);
         return super.getSearchResponse(result, searchRequest.getFields(), request, response);
     }
@@ -275,7 +276,7 @@ public class UniProtKBController extends BasicSearchController<UniProtKBEntry> {
             HttpServletRequest request) {
 
         MediaType contentType = getAcceptHeader(request);
-
+        setBasicRequestFormat(streamRequest, request);
         Optional<String> acceptedRdfContentType = getAcceptedRdfContentType(request);
         if (acceptedRdfContentType.isPresent()) {
             return super.streamRdf(

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/controller/request/UniProtKBBasicRequest.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/controller/request/UniProtKBBasicRequest.java
@@ -50,6 +50,9 @@ public class UniProtKBBasicRequest {
             message = "{search.invalid.includeIsoform}")
     private String includeIsoform;
 
+    @Parameter(hidden = true)
+    private String format;
+
     public boolean isIncludeIsoform() {
         return Boolean.parseBoolean(includeIsoform);
     }

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/controller/request/UniProtKBIdsPostRequest.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/controller/request/UniProtKBIdsPostRequest.java
@@ -11,6 +11,7 @@ import org.uniprot.store.config.UniProtDataType;
 public class UniProtKBIdsPostRequest extends IdsDownloadRequest {
     private String accessions;
     private String fields;
+    private String format;
 
     public String getCommaSeparatedIds() {
         return this.accessions;

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/controller/request/UniProtKBIdsSearchRequest.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/controller/request/UniProtKBIdsSearchRequest.java
@@ -67,6 +67,9 @@ public class UniProtKBIdsSearchRequest implements IdsSearchRequest {
     @ValidSolrSortFields(uniProtDataType = UniProtDataType.UNIPROTKB)
     private String sort;
 
+    @Parameter(hidden = true)
+    private String format;
+
     public String getCommaSeparatedIds() {
         return this.accessions;
     }

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/service/PublicationService.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/service/PublicationService.java
@@ -182,6 +182,7 @@ public class PublicationService extends BasicSearchService<PublicationDocument, 
         private String fields;
         private Integer size;
         private String facets;
+        private String format;
 
         @Override
         public List<String> getFacetList() {

--- a/uniref-rest/src/main/java/org/uniprot/api/uniref/controller/UniRefEntryController.java
+++ b/uniref-rest/src/main/java/org/uniprot/api/uniref/controller/UniRefEntryController.java
@@ -8,7 +8,6 @@ import static org.uniprot.api.rest.output.context.MessageConverterContextFactory
 import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -93,9 +92,7 @@ public class UniRefEntryController extends BasicSearchController<UniRefEntry> {
                         })
             })
     public ResponseEntity<MessageConverterContext<UniRefEntry>> getById(
-            @Valid @ModelAttribute UniRefIdRequest idRequest,
-            HttpServletRequest request,
-            HttpServletResponse response) {
+            @Valid @ModelAttribute UniRefIdRequest idRequest, HttpServletRequest request) {
         Optional<String> acceptedRdfContentType = getAcceptedRdfContentType(request);
         if (acceptedRdfContentType.isPresent()) {
             String rdf =

--- a/uniref-rest/src/main/java/org/uniprot/api/uniref/controller/UniRefEntryLightController.java
+++ b/uniref-rest/src/main/java/org/uniprot/api/uniref/controller/UniRefEntryLightController.java
@@ -187,6 +187,7 @@ public class UniRefEntryLightController extends BasicSearchController<UniRefEntr
             HttpServletRequest request,
             HttpServletResponse response) {
         setPreviewInfo(searchRequest, preview);
+        setBasicRequestFormat(searchRequest, request);
         QueryResult<UniRefEntryLight> results = service.search(searchRequest);
         return super.getSearchResponse(results, searchRequest.getFields(), request, response);
     }
@@ -240,7 +241,7 @@ public class UniRefEntryLightController extends BasicSearchController<UniRefEntr
                     MediaType contentType,
             @RequestHeader(value = "Accept-Encoding", required = false) String encoding,
             HttpServletRequest request) {
-
+        setBasicRequestFormat(streamRequest, request);
         Optional<String> acceptedRdfContentType = getAcceptedRdfContentType(request);
         if (acceptedRdfContentType.isPresent()) {
             return super.streamRdf(

--- a/uniref-rest/src/main/java/org/uniprot/api/uniref/request/UniRefBasicRequest.java
+++ b/uniref-rest/src/main/java/org/uniprot/api/uniref/request/UniRefBasicRequest.java
@@ -52,6 +52,8 @@ public class UniRefBasicRequest {
             message = "{search.uniref.invalid.complete.value}")
     private String complete;
 
+    private String format;
+
     public boolean isComplete() {
         boolean result = false;
         if (Utils.notNullNotEmpty(complete)) {

--- a/uniref-rest/src/main/java/org/uniprot/api/uniref/request/UniRefBasicRequest.java
+++ b/uniref-rest/src/main/java/org/uniprot/api/uniref/request/UniRefBasicRequest.java
@@ -52,6 +52,7 @@ public class UniRefBasicRequest {
             message = "{search.uniref.invalid.complete.value}")
     private String complete;
 
+    @Parameter(hidden = true)
     private String format;
 
     public boolean isComplete() {

--- a/uniref-rest/src/main/java/org/uniprot/api/uniref/request/UniRefIdsPostRequest.java
+++ b/uniref-rest/src/main/java/org/uniprot/api/uniref/request/UniRefIdsPostRequest.java
@@ -18,6 +18,7 @@ import org.uniprot.store.config.UniProtDataType;
 public class UniRefIdsPostRequest extends IdsDownloadRequest {
     private String ids;
     private String fields;
+    private String format;
 
     public String getCommaSeparatedIds() {
         return this.ids;

--- a/uniref-rest/src/main/java/org/uniprot/api/uniref/request/UniRefIdsSearchRequest.java
+++ b/uniref-rest/src/main/java/org/uniprot/api/uniref/request/UniRefIdsSearchRequest.java
@@ -72,6 +72,7 @@ public class UniRefIdsSearchRequest implements IdsSearchRequest {
     @ValidSolrSortFields(uniProtDataType = UniProtDataType.UNIREF)
     private String sort;
 
+    @Parameter(hidden = true)
     private String format;
 
     public String getCommaSeparatedIds() {

--- a/uniref-rest/src/main/java/org/uniprot/api/uniref/request/UniRefIdsSearchRequest.java
+++ b/uniref-rest/src/main/java/org/uniprot/api/uniref/request/UniRefIdsSearchRequest.java
@@ -72,6 +72,8 @@ public class UniRefIdsSearchRequest implements IdsSearchRequest {
     @ValidSolrSortFields(uniProtDataType = UniProtDataType.UNIREF)
     private String sort;
 
+    private String format;
+
     public String getCommaSeparatedIds() {
         return this.ids;
     }

--- a/uniref-rest/src/main/java/org/uniprot/api/uniref/service/UniRefEntryLightService.java
+++ b/uniref-rest/src/main/java/org/uniprot/api/uniref/service/UniRefEntryLightService.java
@@ -134,10 +134,10 @@ public class UniRefEntryLightService
 
     @Override
     public Stream<UniRefEntryLight> stream(StreamRequest request) {
-        UniRefStreamRequest unirefRequest = (UniRefStreamRequest) request;
+        UniRefStreamRequest uniRefRequest = (UniRefStreamRequest) request;
         Stream<UniRefEntryLight> result = super.stream(request);
         if (!LIST_MEDIA_TYPE_VALUE.equals(request.getFormat())) {
-            if (!unirefRequest.isComplete()) {
+            if (!uniRefRequest.isComplete()) {
                 result = result.map(this::removeOverLimitAndCleanMemberId);
             } else {
                 result = result.map(this::cleanMemberId);

--- a/uniref-rest/src/main/java/org/uniprot/api/uniref/service/UniRefEntryLightService.java
+++ b/uniref-rest/src/main/java/org/uniprot/api/uniref/service/UniRefEntryLightService.java
@@ -1,5 +1,7 @@
 package org.uniprot.api.uniref.service;
 
+import static org.uniprot.api.rest.output.UniProtMediaType.LIST_MEDIA_TYPE_VALUE;
+
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -50,8 +52,6 @@ public class UniRefEntryLightService
     private final SearchFieldConfig searchFieldConfig;
     private final RdfStreamer rdfStreamer;
 
-    private final TupleStreamDocumentIdStream documentIdStream;
-
     @Autowired
     public UniRefEntryLightService(
             UniRefQueryRepository repository,
@@ -64,7 +64,7 @@ public class UniRefEntryLightService
             SearchFieldConfig uniRefSearchFieldConfig,
             RdfStreamer unirefRdfStreamer,
             FacetTupleStreamTemplate facetTupleStreamTemplate,
-            TupleStreamDocumentIdStream documentIdStream) {
+            TupleStreamDocumentIdStream solrIdStreamer) {
         super(
                 repository,
                 uniRefQueryResultConverter,
@@ -72,12 +72,12 @@ public class UniRefEntryLightService
                 facetConfig,
                 storeStreamer,
                 uniRefSolrQueryConf,
-                facetTupleStreamTemplate);
+                facetTupleStreamTemplate,
+                solrIdStreamer);
         this.uniRefQueryProcessorConfig = uniRefQueryProcessorConfig;
         this.searchFieldConfig = uniRefSearchFieldConfig;
         this.solrQueryConfig = uniRefSolrQueryConf;
         this.rdfStreamer = unirefRdfStreamer;
-        this.documentIdStream = documentIdStream;
     }
 
     @Override
@@ -107,23 +107,27 @@ public class UniRefEntryLightService
         Set<ProblemPair> warnings =
                 getWarnings(
                         request.getQuery(), uniRefQueryProcessorConfig.getLeadingWildcardFields());
-        if (!unirefRequest.isComplete()) {
-            Stream<UniRefEntryLight> content =
-                    result.getContent().map(this::removeOverLimitAndCleanMemberId);
+        if (!LIST_MEDIA_TYPE_VALUE.equals(request.getFormat())) {
+            if (!unirefRequest.isComplete()) {
+                Stream<UniRefEntryLight> content =
+                        result.getContent().map(this::removeOverLimitAndCleanMemberId);
 
-            result =
-                    QueryResult.of(
-                            content,
-                            result.getPage(),
-                            result.getFacets(),
-                            null,
-                            null,
-                            result.getSuggestions(),
-                            warnings);
-        } else {
-            Stream<UniRefEntryLight> content = result.getContent().map(this::cleanMemberId);
+                result =
+                        QueryResult.of(
+                                content,
+                                result.getPage(),
+                                result.getFacets(),
+                                null,
+                                null,
+                                result.getSuggestions(),
+                                warnings);
+            } else {
+                Stream<UniRefEntryLight> content = result.getContent().map(this::cleanMemberId);
 
-            result = QueryResult.of(content, result.getPage(), result.getFacets(), null, warnings);
+                result =
+                        QueryResult.of(
+                                content, result.getPage(), result.getFacets(), null, warnings);
+            }
         }
         return result;
     }
@@ -132,10 +136,12 @@ public class UniRefEntryLightService
     public Stream<UniRefEntryLight> stream(StreamRequest request) {
         UniRefStreamRequest unirefRequest = (UniRefStreamRequest) request;
         Stream<UniRefEntryLight> result = super.stream(request);
-        if (!unirefRequest.isComplete()) {
-            result = result.map(this::removeOverLimitAndCleanMemberId);
-        } else {
-            result = result.map(this::cleanMemberId);
+        if (!LIST_MEDIA_TYPE_VALUE.equals(request.getFormat())) {
+            if (!unirefRequest.isComplete()) {
+                result = result.map(this::removeOverLimitAndCleanMemberId);
+            } else {
+                result = result.map(this::cleanMemberId);
+            }
         }
         return result;
     }
@@ -156,7 +162,7 @@ public class UniRefEntryLightService
             UniRefStreamRequest streamRequest, String dataType, String format) {
         SolrRequest solrRequest =
                 createSolrRequestBuilder(streamRequest, solrSortClause, solrQueryConfig).build();
-        List<String> entryIds = documentIdStream.fetchIds(solrRequest).collect(Collectors.toList());
+        List<String> entryIds = solrIdStreamer.fetchIds(solrRequest).collect(Collectors.toList());
         return rdfStreamer.stream(entryIds.stream(), dataType, format);
     }
 
@@ -173,6 +179,12 @@ public class UniRefEntryLightService
     @Override
     protected RdfStreamer getRdfStreamer() {
         return this.rdfStreamer;
+    }
+
+    @Override
+    protected UniRefEntryLight mapToThinEntry(String uniRefId) {
+        UniRefEntryLightBuilder builder = new UniRefEntryLightBuilder().id(uniRefId);
+        return builder.build();
     }
 
     private UniRefEntryLight cleanMemberId(UniRefEntryLight entry) {

--- a/uniref-rest/src/test/java/org/uniprot/api/uniref/service/UniRefEntryLightServiceTest.java
+++ b/uniref-rest/src/test/java/org/uniprot/api/uniref/service/UniRefEntryLightServiceTest.java
@@ -1,0 +1,172 @@
+package org.uniprot.api.uniref.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.uniprot.api.rest.output.UniProtMediaType.FASTA_MEDIA_TYPE_VALUE;
+import static org.uniprot.api.rest.output.UniProtMediaType.LIST_MEDIA_TYPE_VALUE;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.uniprot.api.common.repository.search.QueryResult;
+import org.uniprot.api.common.repository.search.SolrQueryConfig;
+import org.uniprot.api.common.repository.search.page.impl.CursorPage;
+import org.uniprot.api.common.repository.solrstream.FacetTupleStreamTemplate;
+import org.uniprot.api.common.repository.stream.document.TupleStreamDocumentIdStream;
+import org.uniprot.api.common.repository.stream.rdf.RdfStreamer;
+import org.uniprot.api.common.repository.stream.store.StoreStreamer;
+import org.uniprot.api.rest.respository.facet.impl.UniRefFacetConfig;
+import org.uniprot.api.rest.service.query.processor.UniProtQueryProcessorConfig;
+import org.uniprot.api.uniref.repository.UniRefQueryRepository;
+import org.uniprot.api.uniref.request.UniRefSearchRequest;
+import org.uniprot.api.uniref.request.UniRefStreamRequest;
+import org.uniprot.core.uniref.UniRefEntryLight;
+import org.uniprot.core.uniref.impl.UniRefEntryLightBuilder;
+import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
+import org.uniprot.store.search.document.uniref.UniRefDocument;
+
+/**
+ * @author sahmad
+ * @created 13/06/2023
+ */
+@ExtendWith(MockitoExtension.class)
+class UniRefEntryLightServiceTest {
+    @Mock private UniRefQueryRepository repository;
+    @Mock private UniRefFacetConfig facetConfig;
+    @Mock private UniRefSortClause uniRefSortClause;
+    @Mock private UniRefLightQueryResultConverter uniRefQueryResultConverter;
+    @Mock private StoreStreamer<UniRefEntryLight> storeStreamer;
+    @Mock private SolrQueryConfig uniRefSolrQueryConf;
+    @Mock private UniProtQueryProcessorConfig uniRefQueryProcessorConfig;
+    @Mock private SearchFieldConfig uniRefSearchFieldConfig;
+    @Mock private RdfStreamer unirefRdfStreamer;
+    @Mock private FacetTupleStreamTemplate facetTupleStreamTemplate;
+    @Mock private TupleStreamDocumentIdStream solrIdStreamer;
+
+    UniRefEntryLightService service;
+
+    @BeforeEach
+    void init() {
+        service =
+                new UniRefEntryLightService(
+                        repository,
+                        facetConfig,
+                        uniRefSortClause,
+                        uniRefQueryResultConverter,
+                        storeStreamer,
+                        uniRefSolrQueryConf,
+                        uniRefQueryProcessorConfig,
+                        uniRefSearchFieldConfig,
+                        unirefRdfStreamer,
+                        facetTupleStreamTemplate,
+                        solrIdStreamer);
+    }
+
+    @Test
+    void search_in_list_format_without_voldemort_being_called() {
+        // when
+        UniRefDocument doc1 = UniRefDocument.builder().id("UniRef100_A0A001").build();
+        UniRefDocument doc2 = UniRefDocument.builder().id("UniRef100_A0A002").build();
+        QueryResult<UniRefDocument> solrResult =
+                QueryResult.of(Stream.of(doc1, doc2), CursorPage.of("", 10));
+        UniRefSearchRequest searchRequest = new UniRefSearchRequest();
+        searchRequest.setQuery("field:value");
+        searchRequest.setFormat(LIST_MEDIA_TYPE_VALUE);
+        searchRequest.setSize(10);
+        when(repository.searchPage(any(), any())).thenReturn(solrResult);
+        // then
+        QueryResult<UniRefEntryLight> result = service.search(searchRequest);
+        List<UniRefEntryLight> entries = result.getContent().collect(Collectors.toList());
+        verify(uniRefQueryResultConverter, never()).apply(any());
+        assertFalse(entries.isEmpty());
+        assertEquals(2, entries.size());
+        List<String> ids =
+                entries.stream()
+                        .map(entry -> entry.getId().getValue())
+                        .collect(Collectors.toList());
+        assertEquals(List.of("UniRef100_A0A001", "UniRef100_A0A002"), ids);
+    }
+
+    @Test
+    void search_in_non_list_format_with_voldemort_being_called() {
+        // when
+        UniRefDocument doc1 = UniRefDocument.builder().id("UniRef100_A0A001").build();
+        UniRefEntryLight entry1 = new UniRefEntryLightBuilder().id("UniRef100_A0A001").build();
+        UniRefDocument doc2 = UniRefDocument.builder().id("UniRef100_A0A002").build();
+        UniRefEntryLight entry2 = new UniRefEntryLightBuilder().id("UniRef100_A0A002").build();
+        QueryResult<UniRefDocument> solrResult =
+                QueryResult.of(Stream.of(doc1, doc2), CursorPage.of("", 10));
+        UniRefSearchRequest searchRequest = new UniRefSearchRequest();
+        searchRequest.setQuery("field:value");
+        searchRequest.setFormat(APPLICATION_JSON_VALUE);
+        searchRequest.setSize(10);
+        when(repository.searchPage(any(), any())).thenReturn(solrResult);
+        when(uniRefQueryResultConverter.apply(doc1)).thenReturn(entry1);
+        when(uniRefQueryResultConverter.apply(doc2)).thenReturn(entry2);
+        // then
+        QueryResult<UniRefEntryLight> result = service.search(searchRequest);
+        List<UniRefEntryLight> entries = result.getContent().collect(Collectors.toList());
+        verify(uniRefQueryResultConverter, times(2)).apply(any());
+        assertFalse(entries.isEmpty());
+        assertEquals(2, entries.size());
+        List<String> ids =
+                entries.stream()
+                        .map(entry -> entry.getId().getValue())
+                        .collect(Collectors.toList());
+        assertEquals(List.of("UniRef100_A0A001", "UniRef100_A0A002"), ids);
+    }
+
+    @Test
+    void stream_in_list_format_without_voldemort_being_called() {
+        UniRefStreamRequest request = new UniRefStreamRequest();
+        List<String> ids =
+                List.of(
+                        "UniRef100_A0A001",
+                        "UniRef100_A0A002",
+                        "UniRef100_A0A003",
+                        "UniRef100_A0A004",
+                        "UniRef100_A0A005");
+        request.setQuery("field:value");
+        request.setFormat(LIST_MEDIA_TYPE_VALUE);
+        when(solrIdStreamer.fetchIds(any())).thenReturn(ids.stream());
+        Stream<UniRefEntryLight> result = service.stream(request);
+        List<UniRefEntryLight> entries = result.collect(Collectors.toList());
+        assertEquals(5, entries.size());
+        assertEquals(
+                ids, entries.stream().map(e -> e.getId().getValue()).collect(Collectors.toList()));
+        verify(storeStreamer, never()).idsToStoreStream(any());
+    }
+
+    @Test
+    void stream_in_non_list_format_with_voldemort_store_streamer_being_called() {
+        UniRefStreamRequest request = new UniRefStreamRequest();
+        List<String> ids =
+                List.of(
+                        "UniRef100_A0A001",
+                        "UniRef100_A0A002",
+                        "UniRef100_A0A003",
+                        "UniRef100_A0A004",
+                        "UniRef100_A0A005");
+        Stream<UniRefEntryLight> entriesStream =
+                ids.stream().map(id -> new UniRefEntryLightBuilder().id(id).build());
+        request.setQuery("field:value");
+        request.setFormat(FASTA_MEDIA_TYPE_VALUE);
+        when(storeStreamer.idsToStoreStream(any())).thenReturn(entriesStream);
+        Stream<UniRefEntryLight> result = service.stream(request);
+        List<UniRefEntryLight> entries = result.collect(Collectors.toList());
+        assertEquals(5, entries.size());
+        assertEquals(
+                ids, entries.stream().map(e -> e.getId().getValue()).collect(Collectors.toList()));
+        verify(storeStreamer, times(1)).idsToStoreStream(any());
+    }
+}


### PR DESCRIPTION
In Solr, only the searchable fields are kept, while Voldemort keeps the entire entry object. Our search APIs utilize Solr to search for entries based on the provided query. The returned IDs from Solr are then used to retrieve the corresponding objects from Voldemort. As the list format provides the IDs only and we already have the IDs from Solr, there is no need to access Voldemort for the complete objects. The same applies to the streaming API, where accessing Voldemort is unnecessary.