### PR TITLE
TRM-29994: Generate jobid hash for idmapping async download

### DIFF
--- a/idmapping-rest/src/main/java/org/uniprot/api/idmapping/service/config/IdMappingDownloadRequestToArrayConverter.java
+++ b/idmapping-rest/src/main/java/org/uniprot/api/idmapping/service/config/IdMappingDownloadRequestToArrayConverter.java
@@ -1,0 +1,27 @@
+package org.uniprot.api.idmapping.service.config;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.uniprot.api.idmapping.controller.request.IdMappingDownloadRequest;
+
+public class IdMappingDownloadRequestToArrayConverter
+        implements Function<IdMappingDownloadRequest, char[]> {
+
+    @Override
+    public char[] apply(IdMappingDownloadRequest request) {
+        StringBuilder builder = new StringBuilder();
+
+        if (Objects.nonNull(request.getJobId())) {
+            builder.append(request.getJobId().strip().toLowerCase());
+        }
+        if (Objects.nonNull(request.getFormat())) {
+            builder.append(request.getFormat().strip().toLowerCase());
+        }
+        if (Objects.nonNull(request.getFields())) {
+            builder.append(request.getFields().strip().toLowerCase());
+        }
+
+        return builder.toString().toCharArray();
+    }
+}

--- a/idmapping-rest/src/test/java/org/uniprot/api/idmapping/service/IdMappingPIRServiceTest.java
+++ b/idmapping-rest/src/test/java/org/uniprot/api/idmapping/service/IdMappingPIRServiceTest.java
@@ -69,9 +69,7 @@ class IdMappingPIRServiceTest {
                 pirService.queryResultPage(pageRequest, mappingResult);
         List<Object> emptyList = List.of();
         // then
-        assertThat(
-                queryResult.getContent().collect(Collectors.toList()),
-                is(emptyList));
+        assertThat(queryResult.getContent().collect(Collectors.toList()), is(emptyList));
         assertThat(queryResult.getExtraOptions(), is(notNullValue()));
         ExtraOptions extraOptions = queryResult.getExtraOptions();
         assertThat(extraOptions.getFailedIds(), is(emptyList));

--- a/idmapping-rest/src/test/java/org/uniprot/api/idmapping/service/config/IdMappingDownloadRequestToArrayConverterTest.java
+++ b/idmapping-rest/src/test/java/org/uniprot/api/idmapping/service/config/IdMappingDownloadRequestToArrayConverterTest.java
@@ -1,0 +1,29 @@
+package org.uniprot.api.idmapping.service.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.uniprot.api.idmapping.controller.request.IdMappingDownloadRequestImpl;
+
+class IdMappingDownloadRequestToArrayConverterTest {
+
+    @Test
+    void canConvertFullRequest() {
+        var converter = new IdMappingDownloadRequestToArrayConverter();
+        IdMappingDownloadRequestImpl request = new IdMappingDownloadRequestImpl();
+        request.setJobId("JOBID ");
+        request.setFormat(" format");
+        request.setFields(" fieldValue ");
+        char[] result = converter.apply(request);
+        assertNotNull(result);
+        assertArrayEquals("jobidformatfieldvalue".toCharArray(), result);
+    }
+
+    @Test
+    void canConvertEmptyRequest() {
+        var converter = new IdMappingDownloadRequestToArrayConverter();
+        char[] result = converter.apply(new IdMappingDownloadRequestImpl());
+        assertNotNull(result);
+        assertArrayEquals(new char[0], result);
+    }
+}


### PR DESCRIPTION
Currently idmapping async download is reusing idmapping jobId. This may cause problems if the user try to execute idmapping async download for multiple format or multiple fields.

We can not reuse idmapping jobid for idmapping async download and need to create a jobid hash based on (idmapping jobid, fields and format), this way if the user request request different values for fields and format, it will generate a different jobid.