### PR TITLE
Springboot upgrade from 2.5 to 2.7

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ services:
   - name: docker:dind
     # explicitly disable tls to avoid docker startup interruption
     command: ["--tls=false"]
-image: maven:3.6.3-jdk-11
+image: maven:3.8.5-openjdk-17
 cache:
   key: "$CI_COMMIT_REF_SLUG"
   paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,7 @@ stages:
 api:settings:
   stage: setup
   before_script:
-    - 'wget --no-cache --no-cookies -O ${MAVEN_SETTINGS} "${URL_MAVEN_SETTINGS}"'
+    - 'curl --location "${URL_MAVEN_SETTINGS}" --output ${MAVEN_SETTINGS}'
   script:
     - if [ ! -f ${MAVEN_SETTINGS} ];
       then echo "CI settings missing";

--- a/aa-rest/src/main/resources/application.properties
+++ b/aa-rest/src/main/resources/application.properties
@@ -5,6 +5,7 @@ server.servlet.context-path=/uniprot/api
 
 spring.jackson.default-property-inclusion=non_null
 search.default.page.size=25
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 
 ############################### Spring configuration for error handling ###############################
 # https://stackoverflow.com/questions/28902374/spring-boot-rest-service-exception-handling

--- a/aa-rest/src/test/resources/application.properties
+++ b/aa-rest/src/test/resources/application.properties
@@ -1,5 +1,6 @@
 ############################### General Config #######################################################
 spring.profiles.active=offline
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 server.port=8090
 server.servlet.context-path=/uniprot/api
 

--- a/common-rest/src/main/resources/application.properties
+++ b/common-rest/src/main/resources/application.properties
@@ -4,3 +4,4 @@ management.endpoints.web.path-mapping.info=info
 management.endpoints.web.exposure.include=metrics,prometheus,health,info
 serviceInfoPath=classpath:service-info.json
 redis.hash.prefix=AsyncDownloadJob
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher

--- a/common-rest/src/test/java/org/uniprot/api/rest/validation/QuerySyntaxValidatorTest.java
+++ b/common-rest/src/test/java/org/uniprot/api/rest/validation/QuerySyntaxValidatorTest.java
@@ -2,9 +2,8 @@ package org.uniprot.api.rest.validation;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import javax.validation.ConstraintValidatorContext;
-
 import org.hamcrest.CoreMatchers;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintViolationBuilder;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorContextImpl;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -38,8 +37,8 @@ class QuerySyntaxValidatorTest {
                 new ValidSolrQuerySyntax.QuerySyntaxValidator();
 
         ConstraintValidatorContextImpl context = Mockito.mock(ConstraintValidatorContextImpl.class);
-        ConstraintValidatorContext.ConstraintViolationBuilder builder =
-                Mockito.mock(ConstraintValidatorContext.ConstraintViolationBuilder.class);
+        HibernateConstraintViolationBuilder builder =
+                Mockito.mock(HibernateConstraintViolationBuilder.class);
         Mockito.when(context.buildConstraintViolationWithTemplate(Mockito.anyString()))
                 .thenReturn(builder);
 

--- a/common-rest/src/test/resources/application.properties
+++ b/common-rest/src/test/resources/application.properties
@@ -1,2 +1,3 @@
 ############################### Service Information #######################################################
 serviceInfoPath=classpath:service-info.json
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher

--- a/help-centre-rest/pom.xml
+++ b/help-centre-rest/pom.xml
@@ -12,9 +12,6 @@
 	<artifactId>help-centre-rest</artifactId>
 
 	<properties>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
-
 		<slf4j.version>1.7.25</slf4j.version>
 		<logback.version>1.2.3</logback.version>
 

--- a/help-centre-rest/src/main/resources/application.properties
+++ b/help-centre-rest/src/main/resources/application.properties
@@ -5,6 +5,7 @@ server.servlet.context-path=/uniprot/api
 
 spring.jackson.default-property-inclusion=non_null
 search.default.page.size=25
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 
 ############################### Spring configuration for error handling ###############################
 # https://stackoverflow.com/questions/28902374/spring-boot-rest-service-exception-handling

--- a/help-centre-rest/src/test/resources/application.properties
+++ b/help-centre-rest/src/test/resources/application.properties
@@ -1,5 +1,6 @@
 ############################### General Config #######################################################
 spring.profiles.active=offline
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 server.port=8090
 server.servlet.context-path=/uniprot/api
 spring.test.mockmvc.print=none

--- a/idmapping-rest/pom.xml
+++ b/idmapping-rest/pom.xml
@@ -11,8 +11,8 @@
 	<artifactId>idmapping-rest</artifactId>
 
 	<properties>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 
 		<slf4j.version>1.7.25</slf4j.version>
 		<logback.version>1.2.3</logback.version>

--- a/idmapping-rest/pom.xml
+++ b/idmapping-rest/pom.xml
@@ -11,9 +11,6 @@
 	<artifactId>idmapping-rest</artifactId>
 
 	<properties>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
-
 		<slf4j.version>1.7.25</slf4j.version>
 		<logback.version>1.2.3</logback.version>
 

--- a/idmapping-rest/src/main/resources/application.properties
+++ b/idmapping-rest/src/main/resources/application.properties
@@ -3,6 +3,7 @@ spring.profiles.active=live,asyncDownload
 server.port=8090
 server.servlet.context-path=/uniprot/api
 search.default.page.size=25
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 
 ############################### Service Information #######################################################
 management.endpoints.web.base-path=/idmapping/admin

--- a/idmapping-rest/src/test/java/org/uniprot/api/idmapping/queue/UniParcIdMappingDownloadResultWriterTest.java
+++ b/idmapping-rest/src/test/java/org/uniprot/api/idmapping/queue/UniParcIdMappingDownloadResultWriterTest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.http.MediaType;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 import org.uniprot.api.common.repository.search.ProblemPair;
@@ -47,8 +49,10 @@ import org.uniprot.store.indexer.uniparc.mockers.UniParcEntryMocker;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class UniParcIdMappingDownloadResultWriterTest {
 
     @Test
@@ -84,6 +88,7 @@ class UniParcIdMappingDownloadResultWriterTest {
     @Test
     void canWriteResultFile() throws IOException {
         ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
         RequestMappingHandlerAdapter contentAdaptor =
                 getMockedRequestMappingHandlerAdapter(objectMapper);
         MessageConverterContextFactory<UniParcEntryPair> converterContextFactory =
@@ -99,6 +104,7 @@ class UniParcIdMappingDownloadResultWriterTest {
 
         DownloadConfigProperties downloadProperties = Mockito.mock(DownloadConfigProperties.class);
         Mockito.when(downloadProperties.getResultFilesFolder()).thenReturn("target");
+        Mockito.when(downloadProperties.getIdFilesFolder()).thenReturn("target");
 
         UniParcIdMappingDownloadResultWriter writer =
                 new UniParcIdMappingDownloadResultWriter(

--- a/idmapping-rest/src/test/java/org/uniprot/api/idmapping/queue/UniProtKBIdMappingDownloadResultWriterTest.java
+++ b/idmapping-rest/src/test/java/org/uniprot/api/idmapping/queue/UniProtKBIdMappingDownloadResultWriterTest.java
@@ -45,6 +45,7 @@ import org.uniprot.store.indexer.uniprot.mockers.UniProtEntryMocker;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 class UniProtKBIdMappingDownloadResultWriterTest {
 
@@ -83,6 +84,7 @@ class UniProtKBIdMappingDownloadResultWriterTest {
     @Test
     void canWriteResultFile() throws IOException {
         ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
         RequestMappingHandlerAdapter contentAdaptor =
                 getMockedRequestMappingHandlerAdapter(objectMapper);
         MessageConverterContextFactory<UniProtKBEntryPair> converterContextFactory =

--- a/idmapping-rest/src/test/java/org/uniprot/api/idmapping/queue/UniRefIdMappingDownloadResultWriterTest.java
+++ b/idmapping-rest/src/test/java/org/uniprot/api/idmapping/queue/UniRefIdMappingDownloadResultWriterTest.java
@@ -49,6 +49,7 @@ import org.uniprot.store.indexer.uniref.mockers.UniRefEntryMocker;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 class UniRefIdMappingDownloadResultWriterTest {
 
@@ -85,6 +86,7 @@ class UniRefIdMappingDownloadResultWriterTest {
     @Test
     void canWriteResultFile() throws IOException {
         ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
         RequestMappingHandlerAdapter contentAdaptor =
                 getMockedRequestMappingHandlerAdapter(objectMapper);
         MessageConverterContextFactory<UniRefEntryPair> converterContextFactory =

--- a/idmapping-rest/src/test/resources/application.properties
+++ b/idmapping-rest/src/test/resources/application.properties
@@ -1,5 +1,6 @@
 ############################### General Config #######################################################
 spring.profiles.active=offline
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 server.port=8090
 server.servlet.context-path=/uniprot/api
 spring.test.mockmvc.print=none

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
 	</description>
 
 	<properties>
+		<junit-jupiter.version>5.8.2</junit-jupiter.version>
 		<jackson-bom.version>2.13.4</jackson-bom.version>
 		<jackson.version>2.13.4</jackson.version>
 		<uniprot-store.version>${project.version}</uniprot-store.version>
@@ -40,7 +41,7 @@
 		<solrj.version>8.5.2</solrj.version>
 		<hamcrest-library.version>2.2</hamcrest-library.version>
 		<mockito.jupiter.version>3.3.3</mockito.jupiter.version>
-		<junit-platform.version>5.6.2</junit-platform.version>
+		<junit-platform.version>5.8.2</junit-platform.version>
 		<commons-compress.version>1.20</commons-compress.version>
 		<lombok.version>1.18.22</lombok.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.15</version>
+		<version>2.7.3</version>
 	</parent>
 
 	<artifactId>uniprot-rest-api</artifactId>
@@ -34,7 +34,7 @@
 		<jacoco.version>0.8.8</jacoco.version>
 		<maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
 
-		<spring.boot.version>2.5.15</spring.boot.version>
+		<spring.boot.version>2.7.3</spring.boot.version>
 		<http-uniprot-private-url>https://wwwdev.ebi.ac.uk/uniprot/artifactory</http-uniprot-private-url>
 		<failsafe.version>2.0.1</failsafe.version>
 		<solr.core>8.5.2</solr.core>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.1.RELEASE</version>
+		<version>2.5.15</version>
 	</parent>
 
 	<artifactId>uniprot-rest-api</artifactId>
@@ -22,16 +22,18 @@
 	</description>
 
 	<properties>
+		<jackson-bom.version>2.13.4</jackson-bom.version>
+		<jackson.version>2.13.4</jackson.version>
 		<uniprot-store.version>${project.version}</uniprot-store.version>
 		<uniprot-core.version>${project.version}</uniprot-core.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<maven.compiler.version>3.8.0</maven.compiler.version>
-		<java.version>11</java.version>
-		<jacoco.version>0.8.5</jacoco.version>
+		<java.version>17</java.version>
+		<jacoco.version>0.8.8</jacoco.version>
 		<maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
 
-		<spring.boot.version>2.3.1.RELEASE</spring.boot.version>
+		<spring.boot.version>2.5.15</spring.boot.version>
 		<http-uniprot-private-url>https://wwwdev.ebi.ac.uk/uniprot/artifactory</http-uniprot-private-url>
 		<failsafe.version>2.0.1</failsafe.version>
 		<solr.core>8.5.2</solr.core>
@@ -40,6 +42,7 @@
 		<mockito.jupiter.version>3.3.3</mockito.jupiter.version>
 		<junit-platform.version>5.6.2</junit-platform.version>
 		<commons-compress.version>1.20</commons-compress.version>
+		<lombok.version>1.18.22</lombok.version>
 
 		<!-- Use most recent failsafe and surefire plugin versions -->
 		<maven-failsafe-plugin.version>2.22.0</maven-failsafe-plugin.version>
@@ -275,7 +278,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<argLine>-Xmx3584m -XX:MaxPermSize=3584m
+					<argLine>-Xmx3584m
+						-XX:MaxMetaspaceSize=3584m
 						-Dlogback.configurationFile=${project.basedir}/../logback-test.xml
 						${argLine}</argLine>
 					<includes>

--- a/proteome-rest/src/main/resources/application.properties
+++ b/proteome-rest/src/main/resources/application.properties
@@ -5,6 +5,7 @@ server.servlet.context-path=/uniprot/api
 
 spring.jackson.default-property-inclusion=non_null
 search.default.page.size=25
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 
 ############################### Spring configuration for error handling ###############################
 # https://stackoverflow.com/questions/28902374/spring-boot-rest-service-exception-handling

--- a/proteome-rest/src/test/resources/application.properties
+++ b/proteome-rest/src/test/resources/application.properties
@@ -1,5 +1,6 @@
 ############################### General Config #######################################################
 spring.profiles.active=offline
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 server.port=8090
 server.servlet.context-path=/uniprot/api
 

--- a/support-data-rest/src/main/resources/application.properties
+++ b/support-data-rest/src/main/resources/application.properties
@@ -5,6 +5,7 @@ server.servlet.context-path=/uniprot/api
 
 spring.jackson.default-property-inclusion=non_null
 search.default.page.size=25
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 
 ############################### Spring configuration for error handling ###############################
 # https://stackoverflow.com/questions/28902374/spring-boot-rest-service-exception-handling

--- a/support-data-rest/src/test/resources/application.properties
+++ b/support-data-rest/src/test/resources/application.properties
@@ -2,6 +2,7 @@
 spring.profiles.active=offline
 spring.test.mockmvc.print=none
 spring.main.banner-mode=off
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 solr.home=target/test-classes/solr-config/uniprot-collections
 solr.lock.type=none
 solr.query.batchSize=10

--- a/uniparc-rest/src/main/resources/application.properties
+++ b/uniparc-rest/src/main/resources/application.properties
@@ -6,6 +6,7 @@ server.max-http-header-size=64KB
 
 spring.jackson.default-property-inclusion=non_null
 search.default.page.size=25
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 
 ############################### Spring configuration for error handling ###############################
 # https://stackoverflow.com/questions/28902374/spring-boot-rest-service-exception-handling

--- a/uniparc-rest/src/test/resources/application.properties
+++ b/uniparc-rest/src/test/resources/application.properties
@@ -1,5 +1,6 @@
 ############################### General Config #######################################################
 spring.profiles.active=offline
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 server.port=8090
 server.servlet.context-path=/uniprot/api
 spring.test.mockmvc.print=none

--- a/uniprotkb-rest/src/main/resources/application.properties
+++ b/uniprotkb-rest/src/main/resources/application.properties
@@ -4,6 +4,7 @@ server.port=8090
 server.servlet.context-path=/uniprot/api
 server.max-http-header-size=64KB
 search.default.page.size=25
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 
 ############################### Service Information #######################################################
 management.endpoints.web.base-path=/uniprotkb/admin

--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/queue/UniProtKBMessageListenerTest.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/queue/UniProtKBMessageListenerTest.java
@@ -19,6 +19,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageBuilder;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -34,6 +36,7 @@ import org.uniprot.api.uniprotkb.controller.request.UniProtKBDownloadRequest;
 import org.uniprot.api.uniprotkb.service.UniProtEntryService;
 
 @ExtendWith({MockitoExtension.class})
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class UniProtKBMessageListenerTest {
     @Mock private MessageConverter converter;
     @Mock private UniProtEntryService service;
@@ -62,6 +65,7 @@ public class UniProtKBMessageListenerTest {
         when(this.jobRepository.findById(jobId)).thenReturn(Optional.of(downloadJob));
         when(this.converter.fromMessage(message)).thenReturn(downloadRequest);
         when(this.downloadConfigProperties.getIdFilesFolder()).thenReturn("target");
+        when(this.downloadConfigProperties.getResultFilesFolder()).thenReturn("target");
         when(this.service.streamIds(downloadRequest)).thenReturn(accessions.stream());
         when(this.asyncDownloadQueueConfigProperties.getRetryMaxCount()).thenReturn(3);
 
@@ -93,6 +97,7 @@ public class UniProtKBMessageListenerTest {
         when(this.jobRepository.findById(jobId)).thenReturn(Optional.of(downloadJob));
         when(this.converter.fromMessage(message)).thenReturn(downloadRequest);
         when(this.downloadConfigProperties.getIdFilesFolder()).thenReturn("target");
+        when(this.downloadConfigProperties.getResultFilesFolder()).thenReturn("target");
         when(this.service.streamIds(downloadRequest)).thenReturn(accessions.stream());
         Mockito.doThrow(new IOException("Forced IO Exception"))
                 .when(this.downloadResultWriter)

--- a/uniprotkb-rest/src/test/resources/application.properties
+++ b/uniprotkb-rest/src/test/resources/application.properties
@@ -1,5 +1,6 @@
 ############################### General Config #######################################################
 spring.profiles.active=offline
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 server.port=8090
 server.servlet.context-path=/uniprot/api
 spring.test.mockmvc.print=none

--- a/uniref-rest/src/main/resources/application.properties
+++ b/uniref-rest/src/main/resources/application.properties
@@ -6,6 +6,7 @@ server.max-http-header-size=64KB
 
 spring.jackson.default-property-inclusion=non_null
 search.default.page.size=25
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 
 ############################### Service Information #######################################################
 management.endpoints.web.base-path=/uniref/admin

--- a/uniref-rest/src/test/java/org/uniprot/api/uniref/queue/UniRefMessageListenerTest.java
+++ b/uniref-rest/src/test/java/org/uniprot/api/uniref/queue/UniRefMessageListenerTest.java
@@ -17,6 +17,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageBuilder;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -33,6 +35,7 @@ import org.uniprot.api.uniref.request.UniRefDownloadRequest;
 import org.uniprot.api.uniref.service.UniRefEntryLightService;
 
 @ExtendWith({MockitoExtension.class})
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class UniRefMessageListenerTest {
     @Mock private MessageConverter converter;
     @Mock private UniRefEntryLightService service;
@@ -62,6 +65,7 @@ public class UniRefMessageListenerTest {
         when(this.jobRepository.findById(jobId)).thenReturn(Optional.of(downloadJob));
         when(this.converter.fromMessage(message)).thenReturn(downloadRequest);
         when(this.downloadConfigProperties.getIdFilesFolder()).thenReturn("target");
+        when(this.downloadConfigProperties.getResultFilesFolder()).thenReturn("target");
         when(this.service.streamIds(downloadRequest)).thenReturn(accessions.stream());
         when(this.asyncDownloadQueueConfigProperties.getRetryMaxCount()).thenReturn(3);
 
@@ -93,6 +97,7 @@ public class UniRefMessageListenerTest {
         when(this.jobRepository.findById(jobId)).thenReturn(Optional.of(downloadJob));
         when(this.converter.fromMessage(message)).thenReturn(downloadRequest);
         when(this.downloadConfigProperties.getIdFilesFolder()).thenReturn("target");
+        when(this.downloadConfigProperties.getResultFilesFolder()).thenReturn("target");
         when(this.service.streamIds(downloadRequest)).thenReturn(accessions.stream());
         Mockito.doThrow(new IOException("Forced IO Exception"))
                 .when(this.downloadResultWriter)

--- a/uniref-rest/src/test/resources/application.properties
+++ b/uniref-rest/src/test/resources/application.properties
@@ -1,3 +1,4 @@
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 # log level to reduce noise
 logging.level.org.apache.zookeeper=ERROR
 search.default.page.size=25

--- a/unisave-rest/pom.xml
+++ b/unisave-rest/pom.xml
@@ -61,7 +61,7 @@
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-entitymanager</artifactId>
-			<version>5.4.3.Final</version>
+			<version>5.6.10.Final</version>
 		</dependency>
 
 		<dependency>

--- a/unisave-rest/src/main/resources/application.properties
+++ b/unisave-rest/src/main/resources/application.properties
@@ -6,6 +6,7 @@ management.endpoints.web.base-path=/unisave/admin
 management.endpoints.web.exposure.include=metrics,prometheus,health,info
 management.health.solr.enabled=false
 serviceInfoPath=classpath:service-info.json
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 
 spring.datasource.url=<CHANGE_IT>
 spring.datasource.username=<CHANGE_IT>

--- a/unisave-rest/src/test/resources/application.properties
+++ b/unisave-rest/src/test/resources/application.properties
@@ -1,5 +1,6 @@
 ############################### General Config #######################################################
 spring.profiles.active=offline
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 spring.test.mockmvc.print=none
 spring.main.banner-mode=off
 serviceInfoPath=classpath:service-info.json


### PR DESCRIPTION
This change includes Java upgrade to 17 from 11. As a part of initial Java 17 upgrade, i used SpringBoot 2.5 and Spark 3.3.2.
It also includes SpringBoot upgrade to 2.7.