### PR TITLE
Async test container imp

### DIFF
--- a/common-rest/src/test/java/org/uniprot/api/rest/controller/AbstractAsyncDownloadIT.java
+++ b/common-rest/src/test/java/org/uniprot/api/rest/controller/AbstractAsyncDownloadIT.java
@@ -17,7 +17,6 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -146,7 +145,6 @@ public abstract class AbstractAsyncDownloadIT extends AbstractDownloadIT {
         verifyIdsAndResultFilesDoNotExist(jobId);
     }
 
-    @Disabled
     @Test
     void sendAndProcessMessageWithUnhandledExceptionShouldBeDiscarded() throws IOException {
         // when

--- a/common-rest/src/test/java/org/uniprot/api/rest/controller/AbstractDownloadControllerIT.java
+++ b/common-rest/src/test/java/org/uniprot/api/rest/controller/AbstractDownloadControllerIT.java
@@ -483,6 +483,7 @@ public abstract class AbstractDownloadControllerIT extends AbstractDownloadIT {
         ResultActions response = callGetJobStatus(jobId);
         // then
         response.andDo(log())
+                .andExpect(status().is(HttpStatus.OK.value()))
                 .andExpect(header().string(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$.jobStatus", Matchers.notNullValue()));
         String responseAsString = response.andReturn().getResponse().getContentAsString();

--- a/common-rest/src/test/java/org/uniprot/api/rest/controller/AbstractDownloadIT.java
+++ b/common-rest/src/test/java/org/uniprot/api/rest/controller/AbstractDownloadIT.java
@@ -73,7 +73,7 @@ public abstract class AbstractDownloadIT extends AbstractStreamControllerIT {
     }
 
     @BeforeAll
-    public void setUpAsyncDownload(){
+    public void setUpAsyncDownload() {
         Duration asyncDuration = Duration.ofMillis(500);
         Awaitility.setDefaultPollDelay(asyncDuration);
         Awaitility.setDefaultPollInterval(asyncDuration);

--- a/common-rest/src/test/java/org/uniprot/api/rest/controller/AbstractDownloadIT.java
+++ b/common-rest/src/test/java/org/uniprot/api/rest/controller/AbstractDownloadIT.java
@@ -20,11 +20,13 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerImageName;
 import org.uniprot.api.rest.download.repository.DownloadJobRepository;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Testcontainers
 public abstract class AbstractDownloadIT extends AbstractStreamControllerIT {
 
     @Value("${download.idFilesFolder}")
@@ -47,6 +49,7 @@ public abstract class AbstractDownloadIT extends AbstractStreamControllerIT {
     @Container
     protected static RabbitMQContainer rabbitMQContainer =
             new RabbitMQContainer(DockerImageName.parse("rabbitmq:3-management"));
+
     @Container
     protected static GenericContainer<?> redisContainer =
             new GenericContainer<>(DockerImageName.parse("redis:6-alpine")).withExposedPorts(6379);

--- a/common-rest/src/test/java/org/uniprot/api/rest/controller/AbstractDownloadIT.java
+++ b/common-rest/src/test/java/org/uniprot/api/rest/controller/AbstractDownloadIT.java
@@ -8,9 +8,11 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +24,7 @@ import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
 import org.testcontainers.utility.DockerImageName;
 import org.uniprot.api.rest.download.repository.DownloadJobRepository;
 
@@ -67,6 +70,13 @@ public abstract class AbstractDownloadIT extends AbstractStreamControllerIT {
         System.setProperty(
                 "uniprot.redis.port", String.valueOf(redisContainer.getFirstMappedPort()));
         propertyRegistry.add("ALLOW_EMPTY_PASSWORD", () -> "yes");
+    }
+
+    @BeforeAll
+    public void setUpAsyncDownload(){
+        Duration asyncDuration = Duration.ofMillis(500);
+        Awaitility.setDefaultPollDelay(asyncDuration);
+        Awaitility.setDefaultPollInterval(asyncDuration);
     }
 
     protected void prepareDownloadFolders() throws IOException {

--- a/common-rest/src/test/java/org/uniprot/api/rest/controller/AbstractDownloadIT.java
+++ b/common-rest/src/test/java/org/uniprot/api/rest/controller/AbstractDownloadIT.java
@@ -19,6 +19,7 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerImageName;
 import org.uniprot.api.rest.download.repository.DownloadJobRepository;
@@ -43,8 +44,10 @@ public abstract class AbstractDownloadIT extends AbstractStreamControllerIT {
 
     @Autowired protected AmqpAdmin amqpAdmin;
 
+    @Container
     protected static RabbitMQContainer rabbitMQContainer =
             new RabbitMQContainer(DockerImageName.parse("rabbitmq:3-management"));
+    @Container
     protected static GenericContainer<?> redisContainer =
             new GenericContainer<>(DockerImageName.parse("redis:6-alpine")).withExposedPorts(6379);
 

--- a/common-rest/src/test/java/org/uniprot/api/rest/download/queue/RedisUtil.java
+++ b/common-rest/src/test/java/org/uniprot/api/rest/download/queue/RedisUtil.java
@@ -67,8 +67,12 @@ public class RedisUtil {
 
     private static Callable<Boolean> jobStatus(
             DownloadJobRepository downloadJobRepository, String jobId, JobStatus status) {
-        return () ->
-                downloadJobRepository.existsById(jobId)
-                        && downloadJobRepository.findById(jobId).get().getStatus() == status;
+        return () -> {
+            Optional<DownloadJob> optJob = downloadJobRepository.findById(jobId);
+            if (optJob.isPresent()) {
+                return (optJob.get().getStatus() == status);
+            }
+            return false;
+        };
     }
 }

--- a/idmapping-rest/src/test/java/org/uniprot/api/idmapping/controller/IdMappingDownloadControllerIT.java
+++ b/idmapping-rest/src/test/java/org/uniprot/api/idmapping/controller/IdMappingDownloadControllerIT.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -63,6 +64,7 @@ import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
 import org.testcontainers.utility.DockerImageName;
 import org.uniprot.api.idmapping.IdMappingREST;
 import org.uniprot.api.idmapping.controller.validator.UniParcIdMappingDownloadRequestValidator;
@@ -176,6 +178,9 @@ public class IdMappingDownloadControllerIT {
 
     @BeforeAll
     public void setUpDownload() throws Exception {
+        Duration asyncDuration = Duration.ofMillis(500);
+        Awaitility.setDefaultPollDelay(asyncDuration);
+        Awaitility.setDefaultPollInterval(asyncDuration);
         Files.createDirectories(Path.of(this.idsFolder));
         Files.createDirectories(Path.of(this.resultFolder));
 

--- a/idmapping-rest/src/test/java/org/uniprot/api/idmapping/controller/IdMappingDownloadControllerIT.java
+++ b/idmapping-rest/src/test/java/org/uniprot/api/idmapping/controller/IdMappingDownloadControllerIT.java
@@ -60,6 +60,7 @@ import org.springframework.web.util.DefaultUriBuilderFactory;
 import org.springframework.web.util.UriBuilder;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerImageName;
 import org.uniprot.api.idmapping.IdMappingREST;
@@ -139,9 +140,11 @@ public class IdMappingDownloadControllerIT {
     private static final UniProtKBEntry TEMPLATE_KB_ENTRY =
             UniProtEntryMocker.create(UniProtEntryMocker.Type.SP_CANONICAL);
 
+    @Container
     protected static final RabbitMQContainer rabbitMQContainer =
             new RabbitMQContainer(DockerImageName.parse("rabbitmq:3-management"));
 
+    @Container
     protected static final GenericContainer<?> redisContainer =
             new GenericContainer<>(DockerImageName.parse("redis:6-alpine")).withExposedPorts(6379);
 

--- a/idmapping-rest/src/test/java/org/uniprot/api/idmapping/controller/IdMappingDownloadControllerIT.java
+++ b/idmapping-rest/src/test/java/org/uniprot/api/idmapping/controller/IdMappingDownloadControllerIT.java
@@ -61,6 +61,7 @@ import org.springframework.web.util.UriBuilder;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerImageName;
 import org.uniprot.api.idmapping.IdMappingREST;
@@ -102,6 +103,7 @@ import com.jayway.jsonpath.JsonPath;
 @WebMvcTest(IdMappingDownloadController.class)
 @ExtendWith(value = {SpringExtension.class})
 @AutoConfigureWebClient
+@Testcontainers
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class IdMappingDownloadControllerIT {
 

--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/queue/UniProtKBAsyncDownloadIT.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/queue/UniProtKBAsyncDownloadIT.java
@@ -1,5 +1,6 @@
 package org.uniprot.api.uniprotkb.queue;
 
+import static org.awaitility.Awaitility.*;
 import static org.mockito.Mockito.*;
 import static org.uniprot.api.rest.download.queue.RedisUtil.*;
 import static org.uniprot.api.rest.output.UniProtMediaType.HDF5_MEDIA_TYPE;
@@ -13,8 +14,8 @@ import java.time.Duration;
 import java.util.List;
 import java.util.stream.Stream;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.solr.client.solrj.SolrClient;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.provider.Arguments;
@@ -51,6 +52,7 @@ import org.uniprot.core.uniprotkb.UniProtKBEntry;
 import org.uniprot.store.datastore.UniProtStoreClient;
 import org.uniprot.store.search.SolrCollection;
 
+@Slf4j
 @ActiveProfiles(profiles = {"offline", "asyncDownload", "integration"})
 @EnableConfigurationProperties
 @PropertySource("classpath:application.properties")
@@ -110,31 +112,32 @@ public class UniProtKBAsyncDownloadIT extends AbstractAsyncDownloadIT {
         MediaType format = UniProtMediaType.HDF5_MEDIA_TYPE;
         DownloadRequest request = createDownloadRequest(query, format);
         String jobId = this.messageService.sendMessage(request);
+        log.info("messageService.sendMessage for jobId: "+jobId);
         // Producer
         verify(this.messageService, never()).alreadyProcessed(jobId);
-        Awaitility.await().until(jobCreatedInRedis(downloadJobRepository, jobId));
-        Awaitility.await()
-                .atMost(Duration.ofSeconds(20))
-                .until(jobErrored(downloadJobRepository, jobId));
+        log.info("verified message for jobId: "+jobId);
+        await().until(jobCreatedInRedis(downloadJobRepository, jobId));
+        await().atMost(Duration.ofSeconds(20)).until(jobErrored(downloadJobRepository, jobId));
+        log.info("After jobErrored await: "+jobId);
         // verify  redis
         verifyRedisEntry(query, jobId, JobStatus.ERROR, 1, true, 0);
+        log.info("verifyRedisEntry ERROR: "+jobId);
         // after certain delay the job should be reprocessed from kb side
-        Awaitility.await()
-                .atMost(Duration.ofSeconds(20))
-                .until(jobUnfinished(downloadJobRepository, jobId));
+        await().atMost(Duration.ofSeconds(20)).until(jobUnfinished(downloadJobRepository, jobId));
         verifyRedisEntry(query, jobId, JobStatus.UNFINISHED, 1, true, 10);
+        log.info("After UNFINISHED status check: "+jobId);
         // then job should be picked by embeddings consumers and set to Running again
         //        await().until(jobRunning(jobId));
         // the job should be completed after sometime by embeddings consumer
-        Awaitility.await()
-                .atMost(Duration.ofSeconds(20))
-                .until(jobFinished(downloadJobRepository, jobId));
+        await().atMost(Duration.ofSeconds(20)).until(jobFinished(downloadJobRepository, jobId));
+        log.info("After jobFinished status check: "+jobId);
         // verify ids file generated from solr
         verifyIdsFile(jobId);
         // verify result file doesn't exist yet
         String fileName = jobId + FileType.GZIP.getExtension();
         Path resultFilePath = Path.of(this.resultFolder + "/" + fileName);
         Assertions.assertFalse(Files.exists(resultFilePath));
+        log.info("Success all passed: "+jobId);
     }
 
     @Override

--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/queue/UniProtKBAsyncDownloadIT.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/queue/UniProtKBAsyncDownloadIT.java
@@ -100,7 +100,6 @@ public class UniProtKBAsyncDownloadIT extends AbstractAsyncDownloadIT {
         setUp(restTemplate);
     }
 
-    @Disabled
     @Test
     void sendAndProcessEmbeddingsH5MessageSuccessfullyAfterRetry() throws IOException {
         doThrow(new RuntimeException("Forced exception for testing on call converter.fromMessage"))

--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/queue/UniProtKBAsyncDownloadIT.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/queue/UniProtKBAsyncDownloadIT.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.solr.client.solrj.SolrClient;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -112,32 +113,32 @@ public class UniProtKBAsyncDownloadIT extends AbstractAsyncDownloadIT {
         MediaType format = UniProtMediaType.HDF5_MEDIA_TYPE;
         DownloadRequest request = createDownloadRequest(query, format);
         String jobId = this.messageService.sendMessage(request);
-        log.info("messageService.sendMessage for jobId: "+jobId);
+        log.info("messageService.sendMessage for jobId: " + jobId);
         // Producer
         verify(this.messageService, never()).alreadyProcessed(jobId);
-        log.info("verified message for jobId: "+jobId);
+        log.info("verified message for jobId: " + jobId);
         await().until(jobCreatedInRedis(downloadJobRepository, jobId));
         await().atMost(Duration.ofSeconds(20)).until(jobErrored(downloadJobRepository, jobId));
-        log.info("After jobErrored await: "+jobId);
+        log.info("After jobErrored await: " + jobId);
         // verify  redis
         verifyRedisEntry(query, jobId, JobStatus.ERROR, 1, true, 0);
-        log.info("verifyRedisEntry ERROR: "+jobId);
+        log.info("verifyRedisEntry ERROR: " + jobId);
         // after certain delay the job should be reprocessed from kb side
         await().atMost(Duration.ofSeconds(20)).until(jobUnfinished(downloadJobRepository, jobId));
         verifyRedisEntry(query, jobId, JobStatus.UNFINISHED, 1, true, 10);
-        log.info("After UNFINISHED status check: "+jobId);
+        log.info("After UNFINISHED status check: " + jobId);
         // then job should be picked by embeddings consumers and set to Running again
         //        await().until(jobRunning(jobId));
         // the job should be completed after sometime by embeddings consumer
         await().atMost(Duration.ofSeconds(20)).until(jobFinished(downloadJobRepository, jobId));
-        log.info("After jobFinished status check: "+jobId);
+        log.info("After jobFinished status check: " + jobId);
         // verify ids file generated from solr
         verifyIdsFile(jobId);
         // verify result file doesn't exist yet
         String fileName = jobId + FileType.GZIP.getExtension();
         Path resultFilePath = Path.of(this.resultFolder + "/" + fileName);
         Assertions.assertFalse(Files.exists(resultFilePath));
-        log.info("Success all passed: "+jobId);
+        log.info("Success all passed: " + jobId);
     }
 
     @Override

--- a/unisave-rest/src/test/java/org/uniprot/api/unisave/output/converter/UniSaveJsonMessageConverterTest.java
+++ b/unisave-rest/src/test/java/org/uniprot/api/unisave/output/converter/UniSaveJsonMessageConverterTest.java
@@ -2,8 +2,6 @@ package org.uniprot.api.unisave.output.converter;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.uniprot.api.unisave.repository.domain.DatabaseEnum.SWISSPROT;
 
 import java.io.ByteArrayOutputStream;

--- a/unisave-rest/src/test/java/org/uniprot/api/unisave/output/converter/UniSaveJsonMessageConverterTest.java
+++ b/unisave-rest/src/test/java/org/uniprot/api/unisave/output/converter/UniSaveJsonMessageConverterTest.java
@@ -6,15 +6,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.uniprot.api.unisave.repository.domain.DatabaseEnum.SWISSPROT;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
 import org.uniprot.api.rest.output.context.MessageConverterContext;
 import org.uniprot.api.unisave.UniSaveEntityMocker;
 import org.uniprot.api.unisave.model.UniSaveEntry;
@@ -30,7 +29,7 @@ class UniSaveJsonMessageConverterTest {
     @Test
     void canWriteJson() throws IOException {
         UniSaveJsonMessageConverter converter = new UniSaveJsonMessageConverter();
-        OutputStream outputStream = mock(OutputStream.class);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         EntryImpl mockEntry = UniSaveEntityMocker.mockEntry("P12345", 1);
         UniSaveEntry entry =
                 UniSaveEntry.builder()
@@ -49,12 +48,7 @@ class UniSaveJsonMessageConverterTest {
         converter.writeContents(
                 messageConverterContext, outputStream, Instant.now(), new AtomicInteger(0));
 
-        ArgumentCaptor<byte[]> byteCaptor = ArgumentCaptor.forClass(byte[].class);
-        verify(outputStream)
-                .write(byteCaptor.capture(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt());
-
-        byte[] bytesWritten = byteCaptor.getValue();
-        String writtenValue = new String(bytesWritten, 0, findEndOfString(bytesWritten));
+        String writtenValue = outputStream.toString(Charset.defaultCharset());
         assertThat(
                 writtenValue,
                 is(


### PR DESCRIPTION
I executed many times the build. And few times it still fails due to an error in sureface plugin, that does not happen locally

285328 [ERROR] Please refer to dump files (if any exist) [date]-jvmRun[N].dump, [date].dumpstream and [date]-jvmRun[N].dumpstream.
285328 [ERROR] The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
285328 [ERROR] Command was /bin/sh -c cd /builds/uniprot/deployment/uniprot-rest-api/uniprotkb-rest && /usr/java/openjdk-17/bin/java -Xmx3584m 						-XX:MaxMetaspaceSize=3584m 						-Dlogback.configurationFile=/builds/uniprot/deployment/uniprot-rest-api/uniprotkb-rest/../logback-test.xml 						-javaagent:/builds/uniprot/deployment/uniprot-rest-api/.m2/repository/org/jacoco/org.jacoco.agent/0.8.8/org.jacoco.agent-0.8.8-runtime.jar=destfile=/builds/uniprot/deployment/uniprot-rest-api/uniprotkb-rest/target/jacoco.exec -jar /builds/uniprot/deployment/uniprot-rest-api/uniprotkb-rest/target/surefire/surefirebooter6215832326156450193.jar /builds/uniprot/deployment/uniprot-rest-api/uniprotkb-rest/target/surefire 2024-02-03T15-13-58_827-jvmRun1 surefire8510828644589877469tmp surefire_3673200288615895841tmp
285328 [ERROR] Error occurred in starting fork, check output in log
285328 [ERROR] Process Exit Code: 99
285328 [ERROR] Crashed tests:
285328 [ERROR] org.uniprot.api.uniprotkb.queue.UniProtKBAsyncDownloadIT
285328 [ERROR] org.apache.maven.surefire.booter.SurefireBooterForkException: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
285328 [ERROR] Command was /bin/sh -c cd /builds/uniprot/deployment/uniprot-rest-api/uniprotkb-rest && /usr/java/openjdk-17/bin/java -Xmx3584m 						-XX:MaxMetaspaceSize=3584m 						-Dlogback.configurationFile=/builds/uniprot/deployment/uniprot-rest-api/uniprotkb-rest/../logback-test.xml 						-javaagent:/builds/uniprot/deployment/uniprot-rest-api/.m2/repository/org/jacoco/org.jacoco.agent/0.8.8/org.jacoco.agent-0.8.8-runtime.jar=destfile=/builds/uniprot/deployment/uniprot-rest-api/uniprotkb-rest/target/jacoco.exec -jar /builds/uniprot/deployment/uniprot-rest-api/uniprotkb-rest/target/surefire/surefirebooter6215832326156450193.jar /builds/uniprot/deployment/uniprot-rest-api/uniprotkb-rest/target/surefire 2024-02-03T15-13-58_827-jvmRun1 surefire8510828644589877469tmp surefire_3673200288615895841tmp
285328 [ERROR] Error occurred in starting fork, check output in log
285328 [ERROR] Process Exit Code: 99
285328 [ERROR] Crashed tests:
285328 [ERROR] org.uniprot.api.uniprotkb.queue.UniProtKBAsyncDownloadIT
285328 [ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork(ForkStarter.java:671)