### PR TITLE
add integration tests

### DIFF
--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBSearchControllerIT.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBSearchControllerIT.java
@@ -214,6 +214,105 @@ class UniProtKBSearchControllerIT extends AbstractSearchWithSuggestionsControlle
                                         "Invalid includeIsoform parameter value. Expected true or false")));
     }
 
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "\"HGNC:3689\"",
+                "FGFR2",
+                "HGNC",
+                "3689",
+                "\"hgnc-HGNC:3689\"",
+                "hgnc-HGNC",
+                "hgnc-3689"
+            })
+    void searchWithHGNCIdAndProperties(String xref) throws Exception {
+        // given
+        UniProtKBEntry entry = UniProtEntryMocker.create(UniProtEntryMocker.Type.SP_CANONICAL);
+        String acc = entry.getPrimaryAccession().getValue();
+        getStoreManager().save(DataStoreManager.StoreType.UNIPROT, entry);
+        // when
+        ResultActions response =
+                getMockMvc()
+                        .perform(
+                                MockMvcRequestBuilders.get(SEARCH_RESOURCE + "?query=xref:" + xref)
+                                        .header(
+                                                HttpHeaders.ACCEPT,
+                                                MediaType.APPLICATION_JSON_VALUE));
+
+        // then
+        response.andDo(MockMvcResultHandlers.log())
+                .andExpect(MockMvcResultMatchers.status().is(HttpStatus.OK.value()))
+                .andExpect(
+                        MockMvcResultMatchers.header()
+                                .string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.results.size()", is(1)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "embl-joined",
+                "embl-JOINED",
+                "joined",
+                "embl-genomic_dna",
+                "embl-Genomic_DNA",
+                "JOINED",
+                "Genomic_DNA",
+                "genomic_dna"
+            })
+    void searchWithEMBLXrefStatus(String xref) throws Exception {
+        // given
+        UniProtKBEntry entry = UniProtEntryMocker.create(UniProtEntryMocker.Type.SP_CANONICAL);
+        String acc = entry.getPrimaryAccession().getValue();
+        getStoreManager().save(DataStoreManager.StoreType.UNIPROT, entry);
+        // when
+        ResultActions response =
+                getMockMvc()
+                        .perform(
+                                MockMvcRequestBuilders.get(SEARCH_RESOURCE + "?query=xref:" + xref)
+                                        .header(
+                                                HttpHeaders.ACCEPT,
+                                                MediaType.APPLICATION_JSON_VALUE));
+
+        // then
+        response.andDo(MockMvcResultHandlers.log())
+                .andExpect(MockMvcResultMatchers.status().is(HttpStatus.OK.value()))
+                .andExpect(
+                        MockMvcResultMatchers.header()
+                                .string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.results.size()", is(1)))
+                .andExpect(
+                        MockMvcResultMatchers.jsonPath("$.results[0].primaryAccession", is(acc)));
+    }
+
+    @Test
+    void searchWithPIRSFXrefEntryName() throws Exception {
+        // given
+        UniProtKBEntry entry = UniProtEntryMocker.create(UniProtEntryMocker.Type.SP_CANONICAL);
+        String acc = entry.getPrimaryAccession().getValue();
+        getStoreManager().save(DataStoreManager.StoreType.UNIPROT, entry);
+        // when
+        ResultActions response =
+                getMockMvc()
+                        .perform(
+                                MockMvcRequestBuilders.get(
+                                                SEARCH_RESOURCE + "?query=xref:pirsf-FGFR")
+                                        .header(
+                                                HttpHeaders.ACCEPT,
+                                                MediaType.APPLICATION_JSON_VALUE));
+
+        // then
+        response.andDo(MockMvcResultHandlers.log())
+                .andExpect(MockMvcResultMatchers.status().is(HttpStatus.OK.value()))
+                .andExpect(
+                        MockMvcResultMatchers.header()
+                                .string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.results.size()", is(1)))
+                .andExpect(
+                        MockMvcResultMatchers.jsonPath(
+                                "$.results[0].primaryAccession", is("P21802")));
+    }
+
     @Test
     void searchWithForwardSlash() throws Exception {
         // given

--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBSearchControllerIT.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBSearchControllerIT.java
@@ -215,16 +215,7 @@ class UniProtKBSearchControllerIT extends AbstractSearchWithSuggestionsControlle
     }
 
     @ParameterizedTest
-    @ValueSource(
-            strings = {
-                "\"HGNC:3689\"",
-                "FGFR2",
-                "HGNC",
-                "3689",
-                "\"hgnc-HGNC:3689\"",
-                "hgnc-HGNC",
-                "hgnc-3689"
-            })
+    @ValueSource(strings = {"\"HGNC:3689\"", "FGFR2", "3689", "\"hgnc-HGNC:3689\"", "hgnc-3689"})
     void searchWithHGNCIdAndProperties(String xref) throws Exception {
         // given
         UniProtKBEntry entry = UniProtEntryMocker.create(UniProtEntryMocker.Type.SP_CANONICAL);


### PR DESCRIPTION
See TRM-28120 and TRM-28058 for all the cases.
Handled cases:
example input(P23470) - DR EMBL; U46089; AAC50439.1; JOINED; Genomic_DNA.

1. xref:embl-joined
2. xref:joined
3. xref:embl-Genomic_DNA
4. xref:pirsf-enteropeptidase
5. xref:enteropeptidase
6. xref:hgnc-HGNC:5984 (see test case paramter for its variants)

Not handled:
DR   CDD; cd12087; TM_EGFR-like; 
1. xref:cdd-egfr (Need to search xref:cdd-tm_egfr-like)
Already working:
DR   TCDB; 8.A.94.1.2; the adiponectin (adiponectin) family.
1. Free text search doesn't return cross ref adiponectin

Not valid since we removed KEGG

1. free text "slr0056" doesn't return any result (DR   KEGG; syn:slr0056; -. )