### PR TITLE
Changes around testcontainers: 

### DIFF
--- a/async-download-rest/src/main/java/org/uniprot/api/async/download/AsyncDownloadRestApp.java
+++ b/async-download-rest/src/main/java/org/uniprot/api/async/download/AsyncDownloadRestApp.java
@@ -33,7 +33,9 @@ import org.uniprot.api.uniprotkb.common.service.uniprotkb.UniSaveClient;
             "org.uniprot.api.rest",
             "org.uniprot.api.uniprotkb.common",
             "org.uniprot.api.uniref.common",
-            "org.uniprot.api.idmapping.common",
+            "org.uniprot.api.idmapping.common.service",
+            "org.uniprot.api.idmapping.common.response",
+            "org.uniprot.api.idmapping.common.repository",
             "org.uniprot.api.common.repository.stream.store.uniprotkb",
             "org.uniprot.api.common.repository.stream.rdf",
             "org.uniprot.api.support.data.common"

--- a/async-download-rest/src/test/java/org/uniprot/api/async/download/common/AbstractDownloadIT.java
+++ b/async-download-rest/src/test/java/org/uniprot/api/async/download/common/AbstractDownloadIT.java
@@ -22,8 +22,6 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 import org.testcontainers.utility.DockerImageName;
@@ -32,12 +30,9 @@ import org.uniprot.api.async.download.messaging.repository.DownloadJobRepository
 import org.uniprot.api.rest.controller.AbstractStreamControllerIT;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@Testcontainers
 public abstract class AbstractDownloadIT extends AbstractStreamControllerIT {
 
     @Autowired protected AmqpAdmin amqpAdmin;
-
-    @Container
     protected static RabbitMQContainer rabbitMQContainer =
             new RabbitMQContainer(DockerImageName.parse("rabbitmq:3-management"))
                     .withExposedPorts(5672, 15672)
@@ -45,7 +40,6 @@ public abstract class AbstractDownloadIT extends AbstractStreamControllerIT {
                     .withStartupTimeout(Duration.ofMinutes(2))
                     .withTmpFs(Map.of("/var/lib/rabbitmq", "rw"));
 
-    @Container
     protected static GenericContainer<?> redisContainer =
             new GenericContainer<>(DockerImageName.parse("redis:6-alpine")).withExposedPorts(6379);
 

--- a/async-download-rest/src/test/java/org/uniprot/api/async/download/common/AbstractIdMappingIT.java
+++ b/async-download-rest/src/test/java/org/uniprot/api/async/download/common/AbstractIdMappingIT.java
@@ -1,0 +1,364 @@
+package org.uniprot.api.async.download.common;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.uniprot.store.indexer.uniref.mockers.UniRefEntryMocker.createEntry;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.Mockito;
+import org.springframework.amqp.core.AmqpAdmin;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+import org.springframework.web.util.UriBuilder;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+import org.testcontainers.utility.DockerImageName;
+import org.uniprot.api.async.download.controller.IdMappingAsyncConfig;
+import org.uniprot.api.async.download.controller.validator.UniParcIdMappingDownloadRequestValidator;
+import org.uniprot.api.async.download.controller.validator.UniProtKBIdMappingDownloadRequestValidator;
+import org.uniprot.api.async.download.controller.validator.UniRefIdMappingDownloadRequestValidator;
+import org.uniprot.api.async.download.messaging.repository.IdMappingDownloadJobRepository;
+import org.uniprot.api.idmapping.common.model.IdMappingJob;
+import org.uniprot.api.idmapping.common.model.IdMappingResult;
+import org.uniprot.api.idmapping.common.request.IdMappingJobRequest;
+import org.uniprot.api.idmapping.common.response.model.IdMappingStringPair;
+import org.uniprot.api.idmapping.common.service.IdMappingJobCacheService;
+import org.uniprot.api.rest.download.model.JobStatus;
+import org.uniprot.api.rest.output.UniProtMediaType;
+import org.uniprot.api.uniparc.common.repository.store.crossref.UniParcCrossReferenceStoreClient;
+import org.uniprot.core.uniparc.UniParcEntry;
+import org.uniprot.core.uniparc.UniParcEntryLight;
+import org.uniprot.core.uniparc.impl.UniParcCrossReferencePair;
+import org.uniprot.core.uniprotkb.UniProtKBEntry;
+import org.uniprot.core.uniprotkb.impl.UniProtKBEntryBuilder;
+import org.uniprot.core.uniref.UniRefEntry;
+import org.uniprot.core.uniref.UniRefEntryLight;
+import org.uniprot.core.uniref.UniRefType;
+import org.uniprot.core.xml.jaxb.uniref.Entry;
+import org.uniprot.core.xml.uniref.UniRefEntryConverter;
+import org.uniprot.core.xml.uniref.UniRefEntryLightConverter;
+import org.uniprot.store.datastore.UniProtStoreClient;
+import org.uniprot.store.indexer.uniparc.mockers.UniParcEntryMocker;
+import org.uniprot.store.indexer.uniprot.mockers.UniProtEntryMocker;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class AbstractIdMappingIT {
+    @Autowired protected IdMappingAsyncConfig idMappingAsyncConfig;
+    @Autowired private AmqpAdmin amqpAdmin;
+
+    @MockBean(name = "idMappingRdfRestTemplate")
+    private RestTemplate idMappingRdfRestTemplate;
+
+    private static final UniProtKBEntry TEMPLATE_KB_ENTRY =
+            UniProtEntryMocker.create(UniProtEntryMocker.Type.SP_CANONICAL);
+    @Autowired protected IdMappingJobCacheService cacheService;
+
+    @Autowired private UniProtStoreClient<UniParcEntryLight> uniParcLightStoreClient;
+
+    @Autowired private UniProtStoreClient<UniProtKBEntry> uniProtKBStoreClient;
+
+    @Autowired private UniParcCrossReferenceStoreClient uniParcCrossReferenceStoreClient;
+    @Autowired protected IdMappingDownloadJobRepository downloadJobRepository;
+
+    @Qualifier("uniRefLightStoreClient")
+    @Autowired
+    private UniProtStoreClient<UniRefEntryLight> uniRefStoreClient;
+
+    static final RabbitMQContainer rabbitMQContainer =
+            new RabbitMQContainer(DockerImageName.parse("rabbitmq:3-management"))
+                    .withExposedPorts(5672, 15672)
+                    .waitingFor(Wait.forLogMessage(".*Server startup complete.*", 1))
+                    .withStartupTimeout(Duration.ofMinutes(2))
+                    .withTmpFs(Map.of("/var/lib/rabbitmq", "rw"));
+
+    static final GenericContainer<?> redisContainer =
+            new GenericContainer<>(DockerImageName.parse("redis:6-alpine")).withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void setUp(DynamicPropertyRegistry propertyRegistry) {
+        Startables.deepStart(rabbitMQContainer, redisContainer).join();
+        assertTrue(rabbitMQContainer.isRunning());
+        assertTrue(redisContainer.isRunning());
+        propertyRegistry.add("spring.amqp.rabbit.port", rabbitMQContainer::getFirstMappedPort);
+        propertyRegistry.add("spring.amqp.rabbit.host", rabbitMQContainer::getHost);
+        System.setProperty("uniprot.redis.host", redisContainer.getHost());
+        System.setProperty(
+                "uniprot.redis.port", String.valueOf(redisContainer.getFirstMappedPort()));
+        propertyRegistry.add("ALLOW_EMPTY_PASSWORD", () -> "yes");
+    }
+
+    @BeforeAll
+    public void setUpDownload() throws Exception {
+        Duration asyncDuration = Duration.ofMillis(500);
+        Awaitility.setDefaultPollDelay(asyncDuration);
+        Awaitility.setDefaultPollInterval(asyncDuration);
+        Files.createDirectories(Path.of(idMappingAsyncConfig.getIdsFolder()));
+        Files.createDirectories(Path.of(idMappingAsyncConfig.getResultFolder()));
+
+        for (int i = 1; i <= 10; i++) {
+            saveUniParc(i);
+            saveUniProtKB(i, "");
+
+            saveUniRef(createEntry(i, UniRefType.UniRef50));
+            saveUniRef(createEntry(i, UniRefType.UniRef90));
+            saveUniRef(createEntry(i, UniRefType.UniRef100));
+        }
+        saveUniProtKB(11, "-2");
+        saveUniProtKB(12, "-2");
+    }
+
+    @BeforeEach
+    public void setUpEach() {
+        DefaultUriBuilderFactory handler = Mockito.mock(DefaultUriBuilderFactory.class);
+        when(idMappingRdfRestTemplate.getUriTemplateHandler()).thenReturn(handler);
+
+        UriBuilder uriBuilder = Mockito.mock(UriBuilder.class);
+        when(handler.builder()).thenReturn(uriBuilder);
+
+        URI uniProtRdfServiceURI = Mockito.mock(URI.class);
+        when(uriBuilder.build(eq("uniprotkb"), eq("rdf"), any())).thenReturn(uniProtRdfServiceURI);
+        when(idMappingRdfRestTemplate.getForObject(eq(uniProtRdfServiceURI), any()))
+                .thenReturn(
+                        "<?xml version='1.0' encoding='UTF-8'?>\n"
+                                + "<rdf:RDF>\n"
+                                + "    <owl:Ontology rdf:about=\"\">\n"
+                                + "        <owl:imports rdf:resource=\"http://purl.uniprot.org/core/\"/>\n"
+                                + "    </owl:Ontology>\n"
+                                + "    <sample>text</sample>\n"
+                                + "    <rdf:Description rdf:about=\"P00001\">\n"
+                                + "    <rdf:Description rdf:about=\"P00002\">\n"
+                                + "</rdf:RDF>");
+
+        URI uniParcRdfServiceURI = Mockito.mock(URI.class);
+        when(uriBuilder.build(eq("uniparc"), eq("rdf"), any())).thenReturn(uniParcRdfServiceURI);
+        when(idMappingRdfRestTemplate.getForObject(eq(uniParcRdfServiceURI), any()))
+                .thenReturn(
+                        "<?xml version='1.0' encoding='UTF-8'?>\n"
+                                + "<rdf:RDF>\n"
+                                + "    <owl:Ontology rdf:about=\"\">\n"
+                                + "        <owl:imports rdf:resource=\"http://purl.uniprot.org/core/\"/>\n"
+                                + "    </owl:Ontology>\n"
+                                + "    <sample>text</sample>\n"
+                                + "    <rdf:Description rdf:about=\"UPI000012A72A\">\n"
+                                + "    <rdf:Description rdf:about=\"UPI000012A73A\">\n"
+                                + "</rdf:RDF>");
+
+        URI uniRefRdfServiceURI = Mockito.mock(URI.class);
+        when(uriBuilder.build(eq("uniref"), eq("rdf"), any())).thenReturn(uniRefRdfServiceURI);
+        when(idMappingRdfRestTemplate.getForObject(eq(uniRefRdfServiceURI), any()))
+                .thenReturn(
+                        "<?xml version='1.0' encoding='UTF-8'?>\n"
+                                + "<rdf:RDF>\n"
+                                + "    <owl:Ontology rdf:about=\"\">\n"
+                                + "        <owl:imports rdf:resource=\"http://purl.uniprot.org/core/\"/>\n"
+                                + "    </owl:Ontology>\n"
+                                + "    <sample>text</sample>\n"
+                                + "    <rdf:Description rdf:about=\"UniRef100_P21802\">\n"
+                                + "    <rdf:Description rdf:about=\"UniRef100_P21803\">\n"
+                                + "</rdf:RDF>");
+
+        URI uniProtNtServiceURI = Mockito.mock(URI.class);
+        when(uriBuilder.build(eq("uniprotkb"), eq("nt"), any())).thenReturn(uniProtNtServiceURI);
+        when(idMappingRdfRestTemplate.getForObject(eq(uniProtNtServiceURI), any()))
+                .thenReturn(
+                        "<http://purl.uniprot.org/uniprot/SAMPLE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.uniprot.org/core/SAMPLE> .\n"
+                                + "<http://purl.uniprot.org/uniprot/P00001> <http://purl.uniprot.org/core/reviewed>\n"
+                                + "<http://purl.uniprot.org/uniprot/P00002> <http://purl.uniprot.org/core/reviewed>");
+
+        URI uniParcNtServiceURI = Mockito.mock(URI.class);
+        when(uriBuilder.build(eq("uniparc"), eq("nt"), any())).thenReturn(uniParcNtServiceURI);
+        when(idMappingRdfRestTemplate.getForObject(eq(uniParcNtServiceURI), any()))
+                .thenReturn(
+                        "<http://purl.uniprot.org/uniprot/SAMPLE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.uniprot.org/core/SAMPLE> .\n"
+                                + "<http://purl.uniprot.org/uniprot/UPI000012A71A> <http://purl.uniprot.org/core/reviewed>\n"
+                                + "<http://purl.uniprot.org/uniprot/UPI000012A72A> <http://purl.uniprot.org/core/reviewed>");
+
+        URI uniRefNtServiceURI = Mockito.mock(URI.class);
+        when(uriBuilder.build(eq("uniref"), eq("nt"), any())).thenReturn(uniRefNtServiceURI);
+        when(idMappingRdfRestTemplate.getForObject(eq(uniRefNtServiceURI), any()))
+                .thenReturn(
+                        "<http://purl.uniprot.org/uniprot/SAMPLE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.uniprot.org/core/SAMPLE> .\n"
+                                + "<http://purl.uniprot.org/uniprot/UniRef100_P21801> <http://purl.uniprot.org/core/reviewed>\n"
+                                + "<http://purl.uniprot.org/uniprot/UniRef100_P21802> <http://purl.uniprot.org/core/reviewed>");
+
+        URI uniProtTtlServiceURI = Mockito.mock(URI.class);
+        when(uriBuilder.build(eq("uniprotkb"), eq("ttl"), any())).thenReturn(uniProtTtlServiceURI);
+        when(idMappingRdfRestTemplate.getForObject(eq(uniProtTtlServiceURI), any()))
+                .thenReturn(
+                        "@prefix uniparc: <http://purl.uniprot.org/uniparc/> .\n"
+                                + "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n"
+                                + "<P00001> rdf:type up:Protein ;\n"
+                                + "<P00002> rdf:type up:Protein ;\n"
+                                + "<SAMPLE> rdf:type up:Protein ;");
+
+        URI uniParcTtlServiceURI = Mockito.mock(URI.class);
+        when(uriBuilder.build(eq("uniparc"), eq("ttl"), any())).thenReturn(uniParcTtlServiceURI);
+        when(idMappingRdfRestTemplate.getForObject(eq(uniParcTtlServiceURI), any()))
+                .thenReturn(
+                        "@prefix uniparc: <http://purl.uniprot.org/uniparc/> .\n"
+                                + "@prefix uniprot: <http://purl.uniprot.org/uniprot/> .\n"
+                                + "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n"
+                                + "<UPI000012A72A> rdf:type up:Protein ;\n"
+                                + "<UPI000012A73A> rdf:type up:Protein ;\n"
+                                + "<SAMPLE> rdf:type up:Protein ;");
+
+        URI uniRefTtlServiceURI = Mockito.mock(URI.class);
+        when(uriBuilder.build(eq("uniref"), eq("ttl"), any())).thenReturn(uniRefTtlServiceURI);
+        when(idMappingRdfRestTemplate.getForObject(eq(uniRefTtlServiceURI), any()))
+                .thenReturn(
+                        "@prefix uniparc: <http://purl.uniprot.org/uniparc/> .\n"
+                                + "@prefix uniprot: <http://purl.uniprot.org/uniprot/> .\n"
+                                + "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n"
+                                + "<UniRef100_P21802> rdf:type up:Protein ;\n"
+                                + "<UniRef100_P21803> rdf:type up:Protein ;\n"
+                                + "<SAMPLE> rdf:type up:Protein ;");
+    }
+
+    private void saveUniProtKB(int i, String isoFormString) {
+        UniProtKBEntryBuilder entryBuilder = UniProtKBEntryBuilder.from(TEMPLATE_KB_ENTRY);
+        String acc = String.format("P%05d", i) + isoFormString;
+        entryBuilder.primaryAccession(acc);
+
+        UniProtKBEntry uniProtKBEntry = entryBuilder.build();
+        uniProtKBStoreClient.saveEntry(uniProtKBEntry);
+    }
+
+    private void saveUniParc(int i) {
+        UniParcEntry uniParcEntry = UniParcEntryMocker.createUniParcEntry(i, "UPI0000283A");
+        UniParcEntryLight uniParcLightEntry =
+                UniParcEntryMocker.convertToUniParcEntryLight(uniParcEntry);
+        uniParcLightStoreClient.saveEntry(uniParcLightEntry);
+        // save cross references in store
+        String xrefBatchKey = uniParcLightEntry.getUniParcId() + "_0";
+        uniParcCrossReferenceStoreClient.saveEntry(
+                new UniParcCrossReferencePair(
+                        xrefBatchKey, uniParcEntry.getUniParcCrossReferences()));
+    }
+
+    private void saveUniRef(UniRefEntry uniRefEntry) {
+        UniRefEntryConverter converter = new UniRefEntryConverter();
+        Entry xmlEntry = converter.toXml(uniRefEntry);
+        UniRefEntryLightConverter unirefLightConverter = new UniRefEntryLightConverter();
+        UniRefEntryLight entryLight = unirefLightConverter.fromXml(xmlEntry);
+        uniRefStoreClient.saveEntry(entryLight);
+    }
+
+    @AfterEach
+    void cleanUpRedisAndFiles() throws IOException {
+        cleanUpFolder(idMappingAsyncConfig.getIdsFolder());
+        cleanUpFolder(idMappingAsyncConfig.getResultFolder());
+        downloadJobRepository.deleteAll();
+    }
+
+    @AfterAll
+    public void cleanUpData() throws IOException {
+        cleanUpFolder(idMappingAsyncConfig.getIdsFolder());
+        cleanUpFolder(idMappingAsyncConfig.getResultFolder());
+        downloadJobRepository.deleteAll();
+        this.amqpAdmin.purgeQueue(idMappingAsyncConfig.getRejectedQueue(), true);
+        this.amqpAdmin.purgeQueue(idMappingAsyncConfig.getDownloadQueue(), true);
+        this.amqpAdmin.purgeQueue(idMappingAsyncConfig.getRetryQueue(), true);
+        this.rabbitMQContainer.stop();
+        this.redisContainer.stop();
+    }
+
+    private void cleanUpFolder(String folder) throws IOException {
+        Files.list(Path.of(folder))
+                .forEach(
+                        path -> {
+                            try {
+                                Files.delete(path);
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+    }
+
+    protected String cleanFormat(String format) {
+        StringBuilder result = new StringBuilder();
+        for (char c : format.toCharArray()) {
+            if (Character.isLetterOrDigit(c)) {
+                result.append(c);
+            }
+        }
+        return result.toString();
+    }
+
+    protected void cacheIdMappingJob(
+            String jobId, String to, JobStatus jobStatus, List<IdMappingStringPair> mappedIds) {
+        cacheIdMappingJob(jobId, to, jobStatus, mappedIds, List.of());
+    }
+
+    protected void cacheIdMappingJob(
+            String jobId,
+            String to,
+            JobStatus jobStatus,
+            List<IdMappingStringPair> mappedIds,
+            List<String> unMappedId) {
+        IdMappingJobRequest idMappingRequest = new IdMappingJobRequest();
+        idMappingRequest.setTo(to);
+
+        IdMappingResult idMappingResult =
+                IdMappingResult.builder().mappedIds(mappedIds).unmappedIds(unMappedId).build();
+
+        IdMappingJob idmappingJob =
+                IdMappingJob.builder()
+                        .jobStatus(jobStatus)
+                        .idMappingRequest(idMappingRequest)
+                        .idMappingResult(idMappingResult)
+                        .build();
+        cacheService.put(jobId, idmappingJob);
+    }
+
+    protected Stream<Arguments> getAllUniProtKBFormats() {
+        return UniProtKBIdMappingDownloadRequestValidator.VALID_FORMATS.stream().map(Arguments::of);
+    }
+
+    protected Stream<Arguments> getAllUniRefFormats() {
+        return UniRefIdMappingDownloadRequestValidator.VALID_FORMATS.stream().map(Arguments::of);
+    }
+
+    protected Stream<Arguments> getAllUniParcFormats() {
+        return UniParcIdMappingDownloadRequestValidator.VALID_FORMATS.stream().map(Arguments::of);
+    }
+
+    protected void validateSupportedRDFMediaTypes(String format, String text) {
+        switch (format) {
+            case UniProtMediaType.TURTLE_MEDIA_TYPE_VALUE:
+                assertTrue(text.contains("@prefix xsd: <http://www.w3.org/2001/XMLSchema#>"));
+                assertTrue(text.contains("<SAMPLE> rdf:type up:Protein ;"));
+                break;
+            case UniProtMediaType.N_TRIPLES_MEDIA_TYPE_VALUE:
+                assertTrue(text.contains("<http://purl.uniprot.org/uniprot/SAMPLE>"));
+                break;
+            case UniProtMediaType.RDF_MEDIA_TYPE_VALUE:
+                assertTrue(text.contains("<rdf:RDF"));
+                assertTrue(text.contains("<sample>text</sample>"));
+                assertTrue(text.contains("</rdf:RDF>"));
+                break;
+            default:
+                fail("Invalid SUPPORTED_RDF_MEDIA_TYPES");
+        }
+    }
+}

--- a/async-download-rest/src/test/java/org/uniprot/api/async/download/common/RedisConfigTest.java
+++ b/async-download-rest/src/test/java/org/uniprot/api/async/download/common/RedisConfigTest.java
@@ -1,10 +1,32 @@
 package org.uniprot.api.async.download.common;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
+import org.redisson.spring.cache.CacheConfig;
+import org.redisson.spring.cache.RedissonSpringCacheManager;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.uniprot.api.idmapping.common.model.IdMappingResult;
+import org.uniprot.api.idmapping.common.request.IdMappingJobRequest;
+import org.uniprot.api.idmapping.common.service.IdMappingJobCacheService;
+import org.uniprot.api.idmapping.common.service.IdMappingPIRService;
+import org.uniprot.api.idmapping.common.service.impl.RedisCacheMappingJobService;
+import org.uniprot.core.uniparc.UniParcEntryLight;
+import org.uniprot.core.uniprotkb.UniProtKBEntry;
+import org.uniprot.core.uniref.UniRefEntryLight;
+import org.uniprot.store.datastore.UniProtStoreClient;
+import org.uniprot.store.datastore.voldemort.light.uniparc.VoldemortInMemoryUniParcEntryLightStore;
+import org.uniprot.store.datastore.voldemort.light.uniref.VoldemortInMemoryUniRefEntryLightStore;
+import org.uniprot.store.datastore.voldemort.uniprot.VoldemortInMemoryUniprotEntryStore;
 
 @TestConfiguration
 public class RedisConfigTest {
@@ -19,5 +41,55 @@ public class RedisConfigTest {
                                 + ":"
                                 + System.getProperty("uniprot.redis.port"));
         return Redisson.create(config);
+    }
+
+    @Bean
+    @Profile("idmapping")
+    public IdMappingJobCacheService idMappingJobCacheService(RedissonClient redissonClient) {
+        Map<String, CacheConfig> config = new HashMap<>();
+        config.put("testMap", null);
+        CacheManager cacheManager = new RedissonSpringCacheManager(redissonClient, config);
+        Cache mappingCache = cacheManager.getCache("testMap");
+        return new RedisCacheMappingJobService(mappingCache);
+    }
+
+    @Bean
+    @Profile("idmapping")
+    public ThreadPoolTaskExecutor jobTaskExecutor() {
+        return new ThreadPoolTaskExecutor();
+    }
+
+    @Bean
+    @Profile("offline")
+    public IdMappingPIRService pirService(
+            @Value("${search.request.converter.defaultRestPageSize:#{null}}")
+                    Integer defaultPageSize) {
+        return new IdMappingPIRService(defaultPageSize) {
+            @Override
+            public IdMappingResult mapIds(IdMappingJobRequest request, String jobId) {
+                return IdMappingResult.builder().build();
+            }
+        };
+    }
+
+    @Bean("uniProtStoreClient")
+    @Profile("offline")
+    public UniProtStoreClient<UniProtKBEntry> uniProtStoreClient() {
+        return new UniProtStoreClient<>(
+                VoldemortInMemoryUniprotEntryStore.getInstance("avro-uniprot"));
+    }
+
+    @Bean("uniRefLightStoreClient")
+    @Profile("offline")
+    public UniProtStoreClient<UniRefEntryLight> uniRefLightStoreClient() {
+        return new UniProtStoreClient<>(
+                VoldemortInMemoryUniRefEntryLightStore.getInstance("avro-uniprot"));
+    }
+
+    @Bean("uniParcLightStoreClient")
+    @Profile("offline")
+    public UniProtStoreClient<UniParcEntryLight> uniParcLightStoreClient() {
+        return new UniProtStoreClient<>(
+                VoldemortInMemoryUniParcEntryLightStore.getInstance("uniparc-light"));
     }
 }

--- a/async-download-rest/src/test/java/org/uniprot/api/async/download/controller/IdMappingDownloadControllerIT.java
+++ b/async-download-rest/src/test/java/org/uniprot/api/async/download/controller/IdMappingDownloadControllerIT.java
@@ -3,9 +3,6 @@ package org.uniprot.api.async.download.controller;
 import static java.util.function.Predicate.isEqual;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.ACCEPT;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -14,92 +11,47 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 import static org.uniprot.api.async.download.common.RedisUtil.jobCreatedInRedis;
-import static org.uniprot.store.indexer.uniref.mockers.UniRefEntryMocker.createEntry;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mockito;
-import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.DefaultUriBuilderFactory;
-import org.springframework.web.util.UriBuilder;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.RabbitMQContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.lifecycle.Startables;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
-import org.testcontainers.utility.DockerImageName;
 import org.uniprot.api.async.download.AsyncDownloadRestApp;
-import org.uniprot.api.async.download.controller.validator.UniParcIdMappingDownloadRequestValidator;
-import org.uniprot.api.async.download.controller.validator.UniProtKBIdMappingDownloadRequestValidator;
-import org.uniprot.api.async.download.controller.validator.UniRefIdMappingDownloadRequestValidator;
-import org.uniprot.api.async.download.messaging.repository.IdMappingDownloadJobRepository;
+import org.uniprot.api.async.download.common.AbstractIdMappingIT;
 import org.uniprot.api.async.download.model.job.idmapping.IdMappingDownloadJob;
-import org.uniprot.api.idmapping.common.model.IdMappingJob;
-import org.uniprot.api.idmapping.common.model.IdMappingResult;
-import org.uniprot.api.idmapping.common.request.IdMappingJobRequest;
 import org.uniprot.api.idmapping.common.response.model.IdMappingStringPair;
-import org.uniprot.api.idmapping.common.service.IdMappingJobCacheService;
 import org.uniprot.api.idmapping.common.service.IdMappingJobService;
-import org.uniprot.api.idmapping.common.service.TestConfig;
 import org.uniprot.api.rest.download.model.JobStatus;
 import org.uniprot.api.rest.output.PredefinedAPIStatus;
 import org.uniprot.api.rest.output.UniProtMediaType;
 import org.uniprot.api.rest.output.context.FileType;
-import org.uniprot.api.uniparc.common.repository.store.crossref.UniParcCrossReferenceStoreClient;
-import org.uniprot.core.uniparc.UniParcEntry;
-import org.uniprot.core.uniparc.UniParcEntryLight;
-import org.uniprot.core.uniparc.impl.UniParcCrossReferencePair;
-import org.uniprot.core.uniprotkb.UniProtKBEntry;
-import org.uniprot.core.uniprotkb.impl.UniProtKBEntryBuilder;
-import org.uniprot.core.uniref.UniRefEntry;
-import org.uniprot.core.uniref.UniRefEntryLight;
-import org.uniprot.core.uniref.UniRefType;
-import org.uniprot.core.xml.jaxb.uniref.Entry;
-import org.uniprot.core.xml.uniref.UniRefEntryConverter;
-import org.uniprot.core.xml.uniref.UniRefEntryLightConverter;
-import org.uniprot.store.datastore.UniProtStoreClient;
-import org.uniprot.store.indexer.uniparc.mockers.UniParcEntryMocker;
-import org.uniprot.store.indexer.uniprot.mockers.UniProtEntryMocker;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -108,51 +60,14 @@ import com.fasterxml.jackson.databind.node.MissingNode;
 import com.jayway.jsonpath.JsonPath;
 
 @ActiveProfiles(profiles = {"offline", "idmapping"})
-@ContextConfiguration(classes = {TestConfig.class, AsyncDownloadRestApp.class})
+@ContextConfiguration(classes = {AsyncDownloadRestApp.class})
 @WebMvcTest(IdMappingDownloadController.class)
 @ExtendWith(value = {SpringExtension.class})
 @AutoConfigureWebClient
-@Testcontainers
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class IdMappingDownloadControllerIT {
-
-    @Autowired private IdMappingAsyncConfig idMappingAsyncConfig;
-
-    @Autowired protected AmqpAdmin amqpAdmin;
-
-    @Autowired protected IdMappingDownloadJobRepository downloadJobRepository;
+class IdMappingDownloadControllerIT extends AbstractIdMappingIT {
 
     @Autowired protected MockMvc mockMvc;
-
-    @Autowired protected IdMappingJobCacheService cacheService;
-
-    @Autowired private UniProtStoreClient<UniParcEntryLight> uniParcLightStoreClient;
-
-    @Autowired private UniProtStoreClient<UniProtKBEntry> uniProtKBStoreClient;
-
-    @Autowired private UniParcCrossReferenceStoreClient uniParcCrossReferenceStoreClient;
-
-    @MockBean(name = "idMappingRdfRestTemplate")
-    private RestTemplate idMappingRdfRestTemplate;
-
-    @Qualifier("uniRefLightStoreClient")
-    @Autowired
-    private UniProtStoreClient<UniRefEntryLight> uniRefStoreClient;
-
-    private static final UniProtKBEntry TEMPLATE_KB_ENTRY =
-            UniProtEntryMocker.create(UniProtEntryMocker.Type.SP_CANONICAL);
-
-    @Container
-    protected static final RabbitMQContainer rabbitMQContainer =
-            new RabbitMQContainer(DockerImageName.parse("rabbitmq:3-management"))
-                    .withExposedPorts(5672, 15672)
-                    .waitingFor(Wait.forLogMessage(".*Server startup complete.*", 1))
-                    .withStartupTimeout(Duration.ofMinutes(2))
-                    .withTmpFs(Map.of("/var/lib/rabbitmq", "rw"));
-
-    @Container
-    protected static final GenericContainer<?> redisContainer =
-            new GenericContainer<>(DockerImageName.parse("redis:6-alpine")).withExposedPorts(6379);
 
     protected static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -164,239 +79,6 @@ public class IdMappingDownloadControllerIT {
 
     protected static final String JOB_DETAILS_ENDPOINT =
             IdMappingJobService.IDMAPPING_PATH + "/download/details/{jobId}";
-
-    @DynamicPropertySource
-    public static void setUp(DynamicPropertyRegistry propertyRegistry) {
-        Startables.deepStart(rabbitMQContainer, redisContainer).join();
-        assertTrue(rabbitMQContainer.isRunning());
-        assertTrue(redisContainer.isRunning());
-        propertyRegistry.add("spring.amqp.rabbit.port", rabbitMQContainer::getFirstMappedPort);
-        propertyRegistry.add("spring.amqp.rabbit.host", rabbitMQContainer::getHost);
-        System.setProperty("uniprot.redis.host", redisContainer.getHost());
-        System.setProperty(
-                "uniprot.redis.port", String.valueOf(redisContainer.getFirstMappedPort()));
-        propertyRegistry.add("ALLOW_EMPTY_PASSWORD", () -> "yes");
-    }
-
-    @BeforeAll
-    public void setUpDownload() throws Exception {
-        Duration asyncDuration = Duration.ofMillis(500);
-        Awaitility.setDefaultPollDelay(asyncDuration);
-        Awaitility.setDefaultPollInterval(asyncDuration);
-        Files.createDirectories(Path.of(idMappingAsyncConfig.getIdsFolder()));
-        Files.createDirectories(Path.of(idMappingAsyncConfig.getResultFolder()));
-
-        for (int i = 1; i <= 10; i++) {
-            saveUniParc(i);
-            saveUniProtKB(i, "");
-
-            saveUniRef(createEntry(i, UniRefType.UniRef50));
-            saveUniRef(createEntry(i, UniRefType.UniRef90));
-            saveUniRef(createEntry(i, UniRefType.UniRef100));
-        }
-        saveUniProtKB(11, "-2");
-        saveUniProtKB(12, "-2");
-    }
-
-    @BeforeEach
-    public void setUpEach() {
-        DefaultUriBuilderFactory handler = Mockito.mock(DefaultUriBuilderFactory.class);
-        when(idMappingRdfRestTemplate.getUriTemplateHandler()).thenReturn(handler);
-
-        UriBuilder uriBuilder = Mockito.mock(UriBuilder.class);
-        when(handler.builder()).thenReturn(uriBuilder);
-
-        URI uniProtRdfServiceURI = Mockito.mock(URI.class);
-        when(uriBuilder.build(eq("uniprotkb"), eq("rdf"), any())).thenReturn(uniProtRdfServiceURI);
-        when(idMappingRdfRestTemplate.getForObject(eq(uniProtRdfServiceURI), any()))
-                .thenReturn(
-                        "<?xml version='1.0' encoding='UTF-8'?>\n"
-                                + "<rdf:RDF>\n"
-                                + "    <owl:Ontology rdf:about=\"\">\n"
-                                + "        <owl:imports rdf:resource=\"http://purl.uniprot.org/core/\"/>\n"
-                                + "    </owl:Ontology>\n"
-                                + "    <sample>text</sample>\n"
-                                + "    <rdf:Description rdf:about=\"P00001\">\n"
-                                + "    <rdf:Description rdf:about=\"P00002\">\n"
-                                + "</rdf:RDF>");
-
-        URI uniParcRdfServiceURI = Mockito.mock(URI.class);
-        when(uriBuilder.build(eq("uniparc"), eq("rdf"), any())).thenReturn(uniParcRdfServiceURI);
-        when(idMappingRdfRestTemplate.getForObject(eq(uniParcRdfServiceURI), any()))
-                .thenReturn(
-                        "<?xml version='1.0' encoding='UTF-8'?>\n"
-                                + "<rdf:RDF>\n"
-                                + "    <owl:Ontology rdf:about=\"\">\n"
-                                + "        <owl:imports rdf:resource=\"http://purl.uniprot.org/core/\"/>\n"
-                                + "    </owl:Ontology>\n"
-                                + "    <sample>text</sample>\n"
-                                + "    <rdf:Description rdf:about=\"UPI000012A72A\">\n"
-                                + "    <rdf:Description rdf:about=\"UPI000012A73A\">\n"
-                                + "</rdf:RDF>");
-
-        URI uniRefRdfServiceURI = Mockito.mock(URI.class);
-        when(uriBuilder.build(eq("uniref"), eq("rdf"), any())).thenReturn(uniRefRdfServiceURI);
-        when(idMappingRdfRestTemplate.getForObject(eq(uniRefRdfServiceURI), any()))
-                .thenReturn(
-                        "<?xml version='1.0' encoding='UTF-8'?>\n"
-                                + "<rdf:RDF>\n"
-                                + "    <owl:Ontology rdf:about=\"\">\n"
-                                + "        <owl:imports rdf:resource=\"http://purl.uniprot.org/core/\"/>\n"
-                                + "    </owl:Ontology>\n"
-                                + "    <sample>text</sample>\n"
-                                + "    <rdf:Description rdf:about=\"UniRef100_P21802\">\n"
-                                + "    <rdf:Description rdf:about=\"UniRef100_P21803\">\n"
-                                + "</rdf:RDF>");
-
-        URI uniProtNtServiceURI = Mockito.mock(URI.class);
-        when(uriBuilder.build(eq("uniprotkb"), eq("nt"), any())).thenReturn(uniProtNtServiceURI);
-        when(idMappingRdfRestTemplate.getForObject(eq(uniProtNtServiceURI), any()))
-                .thenReturn(
-                        "<http://purl.uniprot.org/uniprot/SAMPLE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.uniprot.org/core/SAMPLE> .\n"
-                                + "<http://purl.uniprot.org/uniprot/P00001> <http://purl.uniprot.org/core/reviewed>\n"
-                                + "<http://purl.uniprot.org/uniprot/P00002> <http://purl.uniprot.org/core/reviewed>");
-
-        URI uniParcNtServiceURI = Mockito.mock(URI.class);
-        when(uriBuilder.build(eq("uniparc"), eq("nt"), any())).thenReturn(uniParcNtServiceURI);
-        when(idMappingRdfRestTemplate.getForObject(eq(uniParcNtServiceURI), any()))
-                .thenReturn(
-                        "<http://purl.uniprot.org/uniprot/SAMPLE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.uniprot.org/core/SAMPLE> .\n"
-                                + "<http://purl.uniprot.org/uniprot/UPI000012A71A> <http://purl.uniprot.org/core/reviewed>\n"
-                                + "<http://purl.uniprot.org/uniprot/UPI000012A72A> <http://purl.uniprot.org/core/reviewed>");
-
-        URI uniRefNtServiceURI = Mockito.mock(URI.class);
-        when(uriBuilder.build(eq("uniref"), eq("nt"), any())).thenReturn(uniRefNtServiceURI);
-        when(idMappingRdfRestTemplate.getForObject(eq(uniRefNtServiceURI), any()))
-                .thenReturn(
-                        "<http://purl.uniprot.org/uniprot/SAMPLE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.uniprot.org/core/SAMPLE> .\n"
-                                + "<http://purl.uniprot.org/uniprot/UniRef100_P21801> <http://purl.uniprot.org/core/reviewed>\n"
-                                + "<http://purl.uniprot.org/uniprot/UniRef100_P21802> <http://purl.uniprot.org/core/reviewed>");
-
-        URI uniProtTtlServiceURI = Mockito.mock(URI.class);
-        when(uriBuilder.build(eq("uniprotkb"), eq("ttl"), any())).thenReturn(uniProtTtlServiceURI);
-        when(idMappingRdfRestTemplate.getForObject(eq(uniProtTtlServiceURI), any()))
-                .thenReturn(
-                        "@prefix uniparc: <http://purl.uniprot.org/uniparc/> .\n"
-                                + "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n"
-                                + "<P00001> rdf:type up:Protein ;\n"
-                                + "<P00002> rdf:type up:Protein ;\n"
-                                + "<SAMPLE> rdf:type up:Protein ;");
-
-        URI uniParcTtlServiceURI = Mockito.mock(URI.class);
-        when(uriBuilder.build(eq("uniparc"), eq("ttl"), any())).thenReturn(uniParcTtlServiceURI);
-        when(idMappingRdfRestTemplate.getForObject(eq(uniParcTtlServiceURI), any()))
-                .thenReturn(
-                        "@prefix uniparc: <http://purl.uniprot.org/uniparc/> .\n"
-                                + "@prefix uniprot: <http://purl.uniprot.org/uniprot/> .\n"
-                                + "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n"
-                                + "<UPI000012A72A> rdf:type up:Protein ;\n"
-                                + "<UPI000012A73A> rdf:type up:Protein ;\n"
-                                + "<SAMPLE> rdf:type up:Protein ;");
-
-        URI uniRefTtlServiceURI = Mockito.mock(URI.class);
-        when(uriBuilder.build(eq("uniref"), eq("ttl"), any())).thenReturn(uniRefTtlServiceURI);
-        when(idMappingRdfRestTemplate.getForObject(eq(uniRefTtlServiceURI), any()))
-                .thenReturn(
-                        "@prefix uniparc: <http://purl.uniprot.org/uniparc/> .\n"
-                                + "@prefix uniprot: <http://purl.uniprot.org/uniprot/> .\n"
-                                + "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n"
-                                + "<UniRef100_P21802> rdf:type up:Protein ;\n"
-                                + "<UniRef100_P21803> rdf:type up:Protein ;\n"
-                                + "<SAMPLE> rdf:type up:Protein ;");
-    }
-
-    private void saveUniProtKB(int i, String isoFormString) {
-        UniProtKBEntryBuilder entryBuilder = UniProtKBEntryBuilder.from(TEMPLATE_KB_ENTRY);
-        String acc = String.format("P%05d", i) + isoFormString;
-        entryBuilder.primaryAccession(acc);
-
-        UniProtKBEntry uniProtKBEntry = entryBuilder.build();
-        uniProtKBStoreClient.saveEntry(uniProtKBEntry);
-    }
-
-    private void saveUniParc(int i) {
-        UniParcEntry uniParcEntry = UniParcEntryMocker.createUniParcEntry(i, "UPI0000283A");
-        UniParcEntryLight uniParcLightEntry =
-                UniParcEntryMocker.convertToUniParcEntryLight(uniParcEntry);
-        uniParcLightStoreClient.saveEntry(uniParcLightEntry);
-        // save cross references in store
-        String xrefBatchKey = uniParcLightEntry.getUniParcId() + "_0";
-        uniParcCrossReferenceStoreClient.saveEntry(
-                new UniParcCrossReferencePair(
-                        xrefBatchKey, uniParcEntry.getUniParcCrossReferences()));
-    }
-
-    private void saveUniRef(UniRefEntry uniRefEntry) {
-        UniRefEntryConverter converter = new UniRefEntryConverter();
-        Entry xmlEntry = converter.toXml(uniRefEntry);
-        UniRefEntryLightConverter unirefLightConverter = new UniRefEntryLightConverter();
-        UniRefEntryLight entryLight = unirefLightConverter.fromXml(xmlEntry);
-        uniRefStoreClient.saveEntry(entryLight);
-    }
-
-    @AfterEach
-    void cleanUpRedisAndFiles() throws IOException {
-        cleanUpFolder(idMappingAsyncConfig.getIdsFolder());
-        cleanUpFolder(idMappingAsyncConfig.getResultFolder());
-        downloadJobRepository.deleteAll();
-    }
-
-    @AfterAll
-    public void cleanUpData() {
-        this.amqpAdmin.purgeQueue(idMappingAsyncConfig.getRejectedQueue(), true);
-        this.amqpAdmin.purgeQueue(idMappingAsyncConfig.getDownloadQueue(), true);
-        this.amqpAdmin.purgeQueue(idMappingAsyncConfig.getRetryQueue(), true);
-        rabbitMQContainer.stop();
-        redisContainer.stop();
-    }
-
-    private void cleanUpFolder(String folder) throws IOException {
-        Files.list(Path.of(folder))
-                .forEach(
-                        path -> {
-                            try {
-                                Files.delete(path);
-                            } catch (IOException e) {
-                                throw new RuntimeException(e);
-                            }
-                        });
-    }
-
-    protected String cleanFormat(String format) {
-        StringBuilder result = new StringBuilder();
-        for (char c : format.toCharArray()) {
-            if (Character.isLetterOrDigit(c)) {
-                result.append(c);
-            }
-        }
-        return result.toString();
-    }
-
-    protected void cacheIdMappingJob(
-            String jobId, String to, JobStatus jobStatus, List<IdMappingStringPair> mappedIds) {
-        cacheIdMappingJob(jobId, to, jobStatus, mappedIds, List.of());
-    }
-
-    protected void cacheIdMappingJob(
-            String jobId,
-            String to,
-            JobStatus jobStatus,
-            List<IdMappingStringPair> mappedIds,
-            List<String> unMappedId) {
-        IdMappingJobRequest idMappingRequest = new IdMappingJobRequest();
-        idMappingRequest.setTo(to);
-
-        IdMappingResult idMappingResult =
-                IdMappingResult.builder().mappedIds(mappedIds).unmappedIds(unMappedId).build();
-
-        IdMappingJob idmappingJob =
-                IdMappingJob.builder()
-                        .jobStatus(jobStatus)
-                        .idMappingRequest(idMappingRequest)
-                        .idMappingResult(idMappingResult)
-                        .build();
-        cacheService.put(jobId, idmappingJob);
-    }
 
     protected Callable<JobStatus> jobProcessed(String jobId) {
         return () -> getJobStatus(jobId);
@@ -870,8 +552,7 @@ public class IdMappingDownloadControllerIT {
         String jobResponse = response.andReturn().getResponse().getContentAsString();
         String asyncJobId = JsonPath.read(jobResponse, "$.jobId");
 
-        await().atMost(200, TimeUnit.SECONDS)
-                .until(jobProcessed(asyncJobId), isEqual(JobStatus.FINISHED));
+        await().until(jobProcessed(asyncJobId), isEqual(JobStatus.FINISHED));
         Path resultFilePath =
                 Path.of(
                         idMappingAsyncConfig.getResultFolder()
@@ -1094,8 +775,7 @@ public class IdMappingDownloadControllerIT {
         String jobResponse = response.andReturn().getResponse().getContentAsString();
         String asyncJobId = JsonPath.read(jobResponse, "$.jobId");
 
-        await().atMost(200, TimeUnit.SECONDS)
-                .until(jobProcessed(asyncJobId), isEqual(JobStatus.FINISHED));
+        await().until(jobProcessed(asyncJobId), isEqual(JobStatus.FINISHED));
         Path resultFilePath =
                 Path.of(
                         idMappingAsyncConfig.getResultFolder()
@@ -1318,8 +998,7 @@ public class IdMappingDownloadControllerIT {
         String jobResponse = response.andReturn().getResponse().getContentAsString();
         String asyncJobId = JsonPath.read(jobResponse, "$.jobId");
 
-        await().atMost(200, TimeUnit.SECONDS)
-                .until(jobProcessed(asyncJobId), isEqual(JobStatus.FINISHED));
+        await().until(jobProcessed(asyncJobId), isEqual(JobStatus.FINISHED));
         Path resultFilePath =
                 Path.of(
                         idMappingAsyncConfig.getResultFolder()
@@ -1337,37 +1016,6 @@ public class IdMappingDownloadControllerIT {
         } else {
             assertTrue(text.contains("P00001"));
             assertTrue(text.contains("P00002"));
-        }
-    }
-
-    private Stream<Arguments> getAllUniProtKBFormats() {
-        return UniProtKBIdMappingDownloadRequestValidator.VALID_FORMATS.stream().map(Arguments::of);
-    }
-
-    private Stream<Arguments> getAllUniRefFormats() {
-        return UniRefIdMappingDownloadRequestValidator.VALID_FORMATS.stream().map(Arguments::of);
-    }
-
-    private Stream<Arguments> getAllUniParcFormats() {
-        return UniParcIdMappingDownloadRequestValidator.VALID_FORMATS.stream().map(Arguments::of);
-    }
-
-    private void validateSupportedRDFMediaTypes(String format, String text) {
-        switch (format) {
-            case UniProtMediaType.TURTLE_MEDIA_TYPE_VALUE:
-                assertTrue(text.contains("@prefix xsd: <http://www.w3.org/2001/XMLSchema#>"));
-                assertTrue(text.contains("<SAMPLE> rdf:type up:Protein ;"));
-                break;
-            case UniProtMediaType.N_TRIPLES_MEDIA_TYPE_VALUE:
-                assertTrue(text.contains("<http://purl.uniprot.org/uniprot/SAMPLE>"));
-                break;
-            case UniProtMediaType.RDF_MEDIA_TYPE_VALUE:
-                assertTrue(text.contains("<rdf:RDF"));
-                assertTrue(text.contains("<sample>text</sample>"));
-                assertTrue(text.contains("</rdf:RDF>"));
-                break;
-            default:
-                fail("Invalid SUPPORTED_RDF_MEDIA_TYPES");
         }
     }
 

--- a/async-download-rest/src/test/java/org/uniprot/api/async/download/controller/UniParcDownloadControllerIT.java
+++ b/async-download-rest/src/test/java/org/uniprot/api/async/download/controller/UniParcDownloadControllerIT.java
@@ -44,7 +44,6 @@ import org.uniprot.api.async.download.model.job.DownloadJob;
 import org.uniprot.api.async.download.model.job.uniparc.UniParcDownloadJob;
 import org.uniprot.api.common.repository.solrstream.FacetTupleStreamTemplate;
 import org.uniprot.api.common.repository.stream.common.TupleStreamTemplate;
-import org.uniprot.api.idmapping.common.service.TestConfig;
 import org.uniprot.api.rest.controller.ControllerITUtils;
 import org.uniprot.api.rest.download.model.JobStatus;
 import org.uniprot.api.rest.output.UniProtMediaType;
@@ -67,7 +66,6 @@ import lombok.extern.slf4j.Slf4j;
 @WebMvcTest({UniParcDownloadController.class})
 @ContextConfiguration(
         classes = {
-            TestConfig.class,
             UniParcDataStoreTestConfig.class,
             UniProtKBDataStoreTestConfig.class,
             AsyncDownloadRestApp.class,

--- a/async-download-rest/src/test/java/org/uniprot/api/async/download/controller/UniProtKBDownloadControllerIT.java
+++ b/async-download-rest/src/test/java/org/uniprot/api/async/download/controller/UniProtKBDownloadControllerIT.java
@@ -48,7 +48,6 @@ import org.uniprot.api.async.download.model.request.ValidDownloadRequest;
 import org.uniprot.api.common.repository.solrstream.FacetTupleStreamTemplate;
 import org.uniprot.api.common.repository.stream.common.TupleStreamTemplate;
 import org.uniprot.api.common.repository.stream.store.uniprotkb.TaxonomyLineageRepository;
-import org.uniprot.api.idmapping.common.service.TestConfig;
 import org.uniprot.api.rest.controller.ControllerITUtils;
 import org.uniprot.api.rest.download.model.JobStatus;
 import org.uniprot.api.rest.output.PredefinedAPIStatus;
@@ -71,7 +70,6 @@ import lombok.extern.slf4j.Slf4j;
 @WebMvcTest({UniProtKBDownloadController.class})
 @ContextConfiguration(
         classes = {
-            TestConfig.class,
             UniProtKBDataStoreTestConfig.class,
             AsyncDownloadRestApp.class,
             ErrorHandlerConfig.class,

--- a/async-download-rest/src/test/java/org/uniprot/api/async/download/controller/UniRefDownloadControllerIT.java
+++ b/async-download-rest/src/test/java/org/uniprot/api/async/download/controller/UniRefDownloadControllerIT.java
@@ -40,7 +40,6 @@ import org.uniprot.api.async.download.model.job.DownloadJob;
 import org.uniprot.api.async.download.model.job.uniref.UniRefDownloadJob;
 import org.uniprot.api.common.repository.solrstream.FacetTupleStreamTemplate;
 import org.uniprot.api.common.repository.stream.common.TupleStreamTemplate;
-import org.uniprot.api.idmapping.common.service.TestConfig;
 import org.uniprot.api.rest.controller.ControllerITUtils;
 import org.uniprot.api.rest.download.model.JobStatus;
 import org.uniprot.api.rest.output.UniProtMediaType;
@@ -63,7 +62,6 @@ import lombok.extern.slf4j.Slf4j;
 @WebMvcTest({UniRefDownloadController.class})
 @ContextConfiguration(
         classes = {
-            TestConfig.class,
             UniRefDataStoreTestConfig.class,
             UniProtKBDataStoreTestConfig.class,
             AsyncDownloadRestApp.class,

--- a/async-download-rest/src/test/java/org/uniprot/api/async/download/messaging/consumer/idmapping/IdMappingMessageConsumerIT.java
+++ b/async-download-rest/src/test/java/org/uniprot/api/async/download/messaging/consumer/idmapping/IdMappingMessageConsumerIT.java
@@ -1,92 +1,52 @@
 package org.uniprot.api.async.download.messaging.consumer.idmapping;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 import static org.uniprot.api.async.download.messaging.consumer.MessageConsumer.CURRENT_RETRIED_COUNT_HEADER;
 import static org.uniprot.api.rest.download.model.JobStatus.*;
-import static org.uniprot.store.indexer.uniref.mockers.UniRefEntryMocker.createEntry;
 
-import java.io.*;
-import java.net.URI;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mockito;
-import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.*;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.DefaultUriBuilderFactory;
-import org.springframework.web.util.UriBuilder;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.RabbitMQContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.lifecycle.Startables;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
-import org.testcontainers.utility.DockerImageName;
 import org.uniprot.api.async.download.AsyncDownloadRestApp;
-import org.uniprot.api.async.download.controller.IdMappingAsyncConfig;
-import org.uniprot.api.async.download.controller.validator.UniParcIdMappingDownloadRequestValidator;
-import org.uniprot.api.async.download.controller.validator.UniProtKBIdMappingDownloadRequestValidator;
-import org.uniprot.api.async.download.controller.validator.UniRefIdMappingDownloadRequestValidator;
+import org.uniprot.api.async.download.common.AbstractIdMappingIT;
 import org.uniprot.api.async.download.messaging.config.idmapping.IdMappingDownloadConfigProperties;
-import org.uniprot.api.async.download.messaging.repository.IdMappingDownloadJobRepository;
 import org.uniprot.api.async.download.messaging.result.idmapping.IdMappingFileHandler;
 import org.uniprot.api.async.download.model.job.idmapping.IdMappingDownloadJob;
 import org.uniprot.api.async.download.model.request.idmapping.IdMappingDownloadRequest;
-import org.uniprot.api.idmapping.common.model.IdMappingJob;
-import org.uniprot.api.idmapping.common.model.IdMappingResult;
-import org.uniprot.api.idmapping.common.request.IdMappingJobRequest;
 import org.uniprot.api.idmapping.common.response.model.IdMappingStringPair;
-import org.uniprot.api.idmapping.common.service.IdMappingJobCacheService;
-import org.uniprot.api.idmapping.common.service.TestConfig;
 import org.uniprot.api.rest.download.model.JobStatus;
 import org.uniprot.api.rest.output.UniProtMediaType;
 import org.uniprot.api.rest.output.context.FileType;
-import org.uniprot.core.uniparc.UniParcEntry;
-import org.uniprot.core.uniparc.UniParcEntryLight;
-import org.uniprot.core.uniparc.impl.UniParcCrossReferencePair;
-import org.uniprot.core.uniprotkb.UniProtKBEntry;
-import org.uniprot.core.uniprotkb.impl.UniProtKBEntryBuilder;
-import org.uniprot.core.uniref.UniRefEntry;
-import org.uniprot.core.uniref.UniRefEntryLight;
-import org.uniprot.core.uniref.UniRefType;
-import org.uniprot.core.xml.jaxb.uniref.Entry;
-import org.uniprot.core.xml.uniref.UniRefEntryConverter;
-import org.uniprot.core.xml.uniref.UniRefEntryLightConverter;
-import org.uniprot.store.datastore.UniProtStoreClient;
-import org.uniprot.store.indexer.uniparc.mockers.UniParcEntryMocker;
-import org.uniprot.store.indexer.uniprot.mockers.UniProtEntryMocker;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -94,13 +54,12 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.MissingNode;
 
 @ActiveProfiles(profiles = {"offline", "idmapping"})
-@ContextConfiguration(classes = {TestConfig.class, AsyncDownloadRestApp.class})
+@ContextConfiguration(classes = {AsyncDownloadRestApp.class})
 @ExtendWith(SpringExtension.class)
 @WebAppConfiguration
-@Testcontainers
 @TestPropertySource("classpath:application.properties")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class IdMappingMessageConsumerIT {
+class IdMappingMessageConsumerIT extends AbstractIdMappingIT {
     private static final String ID = "someId";
     private static final String JOB_ID_HEADER = "jobId";
     private static final int MAX_RETRY_COUNT = 3;
@@ -108,285 +67,17 @@ public class IdMappingMessageConsumerIT {
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final long PROCESSED_ENTRIES = 23;
 
-    @Autowired private IdMappingAsyncConfig idMappingAsyncConfig;
-
-    @Autowired private AmqpAdmin amqpAdmin;
-
-    @Autowired private IdMappingDownloadJobRepository downloadJobRepository;
-
-    @Autowired private IdMappingJobCacheService cacheService;
-
     @Autowired private IdMappingDownloadConfigProperties downloadConfigProperties;
-
-    @Autowired private UniProtStoreClient<UniParcEntryLight> uniParcLightStoreClient;
-
-    @Autowired private UniProtStoreClient<UniProtKBEntry> uniProtKBStoreClient;
 
     @Autowired private IdMappingFileHandler asyncDownloadFileHandler;
 
     @Autowired private IdMappingMessageConsumer idMappingMessageConsumer;
 
-    @Autowired private UniProtStoreClient<UniParcCrossReferencePair> xrefStoreClient;
-
-    @MockBean(name = "idMappingRdfRestTemplate")
-    private RestTemplate idMappingRdfRestTemplate;
-
-    @Qualifier("uniRefLightStoreClient")
-    @Autowired
-    private UniProtStoreClient<UniRefEntryLight> uniRefStoreClient;
-
     @Autowired private MessageConverter messageConverter;
 
-    private static final UniProtKBEntry TEMPLATE_KB_ENTRY =
-            UniProtEntryMocker.create(UniProtEntryMocker.Type.SP_CANONICAL);
-
-    @Container
-    private static final RabbitMQContainer rabbitMQContainer =
-            new RabbitMQContainer(DockerImageName.parse("rabbitmq:3-management"))
-                    .withExposedPorts(5672, 15672)
-                    .waitingFor(Wait.forLogMessage(".*Server startup complete.*", 1))
-                    .withStartupTimeout(Duration.ofMinutes(2))
-                    .withTmpFs(Map.of("/var/lib/rabbitmq", "rw"));
-
-    @Container
-    private static final GenericContainer<?> redisContainer =
-            new GenericContainer<>(DockerImageName.parse("redis:6-alpine")).withExposedPorts(6379);
-
-    @Autowired private IdMappingDownloadJobRepository idMappingDownloadJobRepository;
-
-    @DynamicPropertySource
-    public static void setUp(DynamicPropertyRegistry propertyRegistry) {
-        Startables.deepStart(rabbitMQContainer, redisContainer).join();
-        assertTrue(rabbitMQContainer.isRunning());
-        assertTrue(redisContainer.isRunning());
-        propertyRegistry.add("spring.amqp.rabbit.port", rabbitMQContainer::getFirstMappedPort);
-        propertyRegistry.add("spring.amqp.rabbit.host", rabbitMQContainer::getHost);
-        System.setProperty("uniprot.redis.host", redisContainer.getHost());
-        System.setProperty(
-                "uniprot.redis.port", String.valueOf(redisContainer.getFirstMappedPort()));
-        propertyRegistry.add("ALLOW_EMPTY_PASSWORD", () -> "yes");
-    }
-
-    @BeforeAll
-    public void setUpDownload() throws Exception {
-        Duration asyncDuration = Duration.ofMillis(500);
-        Awaitility.setDefaultPollDelay(asyncDuration);
-        Awaitility.setDefaultPollInterval(asyncDuration);
-        Files.createDirectories(Path.of(idMappingAsyncConfig.getIdsFolder()));
-        Files.createDirectories(Path.of(idMappingAsyncConfig.getResultFolder()));
-
-        for (int i = 1; i <= 10; i++) {
-            saveUniParc(i);
-            saveUniProtKB(i, "");
-
-            saveUniRef(createEntry(i, UniRefType.UniRef50));
-            saveUniRef(createEntry(i, UniRefType.UniRef90));
-            saveUniRef(createEntry(i, UniRefType.UniRef100));
-        }
-        saveUniProtKB(11, "-2");
-        saveUniProtKB(12, "-2");
-    }
-
-    @BeforeEach
-    public void setUpEach() {
-        DefaultUriBuilderFactory handler = Mockito.mock(DefaultUriBuilderFactory.class);
-        when(idMappingRdfRestTemplate.getUriTemplateHandler()).thenReturn(handler);
-
-        UriBuilder uriBuilder = Mockito.mock(UriBuilder.class);
-        when(handler.builder()).thenReturn(uriBuilder);
-
-        URI uniProtRdfServiceURI = Mockito.mock(URI.class);
-        when(uriBuilder.build(eq("uniprotkb"), eq("rdf"), any())).thenReturn(uniProtRdfServiceURI);
-        when(idMappingRdfRestTemplate.getForObject(eq(uniProtRdfServiceURI), any()))
-                .thenReturn(
-                        "<?xml version='1.0' encoding='UTF-8'?>\n"
-                                + "<rdf:RDF>\n"
-                                + "    <owl:Ontology rdf:about=\"\">\n"
-                                + "        <owl:imports rdf:resource=\"http://purl.uniprot.org/core/\"/>\n"
-                                + "    </owl:Ontology>\n"
-                                + "    <sample>text</sample>\n"
-                                + "    <rdf:Description rdf:about=\"P00001\">\n"
-                                + "    <rdf:Description rdf:about=\"P00002\">\n"
-                                + "</rdf:RDF>");
-
-        URI uniParcRdfServiceURI = Mockito.mock(URI.class);
-        when(uriBuilder.build(eq("uniparc"), eq("rdf"), any())).thenReturn(uniParcRdfServiceURI);
-        when(idMappingRdfRestTemplate.getForObject(eq(uniParcRdfServiceURI), any()))
-                .thenReturn(
-                        "<?xml version='1.0' encoding='UTF-8'?>\n"
-                                + "<rdf:RDF>\n"
-                                + "    <owl:Ontology rdf:about=\"\">\n"
-                                + "        <owl:imports rdf:resource=\"http://purl.uniprot.org/core/\"/>\n"
-                                + "    </owl:Ontology>\n"
-                                + "    <sample>text</sample>\n"
-                                + "    <rdf:Description rdf:about=\"UPI000012A72A\">\n"
-                                + "    <rdf:Description rdf:about=\"UPI000012A73A\">\n"
-                                + "</rdf:RDF>");
-
-        URI uniRefRdfServiceURI = Mockito.mock(URI.class);
-        when(uriBuilder.build(eq("uniref"), eq("rdf"), any())).thenReturn(uniRefRdfServiceURI);
-        when(idMappingRdfRestTemplate.getForObject(eq(uniRefRdfServiceURI), any()))
-                .thenReturn(
-                        "<?xml version='1.0' encoding='UTF-8'?>\n"
-                                + "<rdf:RDF>\n"
-                                + "    <owl:Ontology rdf:about=\"\">\n"
-                                + "        <owl:imports rdf:resource=\"http://purl.uniprot.org/core/\"/>\n"
-                                + "    </owl:Ontology>\n"
-                                + "    <sample>text</sample>\n"
-                                + "    <rdf:Description rdf:about=\"UniRef100_P21802\">\n"
-                                + "    <rdf:Description rdf:about=\"UniRef100_P21803\">\n"
-                                + "</rdf:RDF>");
-
-        URI uniProtNtServiceURI = Mockito.mock(URI.class);
-        when(uriBuilder.build(eq("uniprotkb"), eq("nt"), any())).thenReturn(uniProtNtServiceURI);
-        when(idMappingRdfRestTemplate.getForObject(eq(uniProtNtServiceURI), any()))
-                .thenReturn(
-                        "<http://purl.uniprot.org/uniprot/SAMPLE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.uniprot.org/core/SAMPLE> .\n"
-                                + "<http://purl.uniprot.org/uniprot/P00001> <http://purl.uniprot.org/core/reviewed>\n"
-                                + "<http://purl.uniprot.org/uniprot/P00002> <http://purl.uniprot.org/core/reviewed>");
-
-        URI uniParcNtServiceURI = Mockito.mock(URI.class);
-        when(uriBuilder.build(eq("uniparc"), eq("nt"), any())).thenReturn(uniParcNtServiceURI);
-        when(idMappingRdfRestTemplate.getForObject(eq(uniParcNtServiceURI), any()))
-                .thenReturn(
-                        "<http://purl.uniprot.org/uniprot/SAMPLE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.uniprot.org/core/SAMPLE> .\n"
-                                + "<http://purl.uniprot.org/uniprot/UPI000012A71A> <http://purl.uniprot.org/core/reviewed>\n"
-                                + "<http://purl.uniprot.org/uniprot/UPI000012A72A> <http://purl.uniprot.org/core/reviewed>");
-
-        URI uniRefNtServiceURI = Mockito.mock(URI.class);
-        when(uriBuilder.build(eq("uniref"), eq("nt"), any())).thenReturn(uniRefNtServiceURI);
-        when(idMappingRdfRestTemplate.getForObject(eq(uniRefNtServiceURI), any()))
-                .thenReturn(
-                        "<http://purl.uniprot.org/uniprot/SAMPLE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.uniprot.org/core/SAMPLE> .\n"
-                                + "<http://purl.uniprot.org/uniprot/UniRef100_P21801> <http://purl.uniprot.org/core/reviewed>\n"
-                                + "<http://purl.uniprot.org/uniprot/UniRef100_P21802> <http://purl.uniprot.org/core/reviewed>");
-
-        URI uniProtTtlServiceURI = Mockito.mock(URI.class);
-        when(uriBuilder.build(eq("uniprotkb"), eq("ttl"), any())).thenReturn(uniProtTtlServiceURI);
-        when(idMappingRdfRestTemplate.getForObject(eq(uniProtTtlServiceURI), any()))
-                .thenReturn(
-                        "@prefix uniparc: <http://purl.uniprot.org/uniparc/> .\n"
-                                + "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n"
-                                + "<P00001> rdf:type up:Protein ;\n"
-                                + "<P00002> rdf:type up:Protein ;\n"
-                                + "<SAMPLE> rdf:type up:Protein ;");
-
-        URI uniParcTtlServiceURI = Mockito.mock(URI.class);
-        when(uriBuilder.build(eq("uniparc"), eq("ttl"), any())).thenReturn(uniParcTtlServiceURI);
-        when(idMappingRdfRestTemplate.getForObject(eq(uniParcTtlServiceURI), any()))
-                .thenReturn(
-                        "@prefix uniparc: <http://purl.uniprot.org/uniparc/> .\n"
-                                + "@prefix uniprot: <http://purl.uniprot.org/uniprot/> .\n"
-                                + "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n"
-                                + "<UPI000012A72A> rdf:type up:Protein ;\n"
-                                + "<UPI000012A73A> rdf:type up:Protein ;\n"
-                                + "<SAMPLE> rdf:type up:Protein ;");
-
-        URI uniRefTtlServiceURI = Mockito.mock(URI.class);
-        when(uriBuilder.build(eq("uniref"), eq("ttl"), any())).thenReturn(uniRefTtlServiceURI);
-        when(idMappingRdfRestTemplate.getForObject(eq(uniRefTtlServiceURI), any()))
-                .thenReturn(
-                        "@prefix uniparc: <http://purl.uniprot.org/uniparc/> .\n"
-                                + "@prefix uniprot: <http://purl.uniprot.org/uniprot/> .\n"
-                                + "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n"
-                                + "<UniRef100_P21802> rdf:type up:Protein ;\n"
-                                + "<UniRef100_P21803> rdf:type up:Protein ;\n"
-                                + "<SAMPLE> rdf:type up:Protein ;");
-    }
-
-    private void saveUniProtKB(int i, String isoFormString) {
-        UniProtKBEntryBuilder entryBuilder = UniProtKBEntryBuilder.from(TEMPLATE_KB_ENTRY);
-        String acc = String.format("P%05d", i) + isoFormString;
-        entryBuilder.primaryAccession(acc);
-
-        UniProtKBEntry uniProtKBEntry = entryBuilder.build();
-        uniProtKBStoreClient.saveEntry(uniProtKBEntry);
-    }
-
-    private void saveUniParc(int i) {
-        UniParcEntry uniParcEntry = UniParcEntryMocker.createUniParcEntry(i, "UPI0000283A");
-        UniParcEntryLight uniParcLightEntry =
-                UniParcEntryMocker.convertToUniParcEntryLight(uniParcEntry);
-        uniParcLightStoreClient.saveEntry(uniParcLightEntry);
-        // save cross references in store
-        String xrefBatchKey = uniParcLightEntry.getUniParcId() + "_0";
-        xrefStoreClient.saveEntry(
-                new UniParcCrossReferencePair(
-                        xrefBatchKey, uniParcEntry.getUniParcCrossReferences()));
-    }
-
-    private void saveUniRef(UniRefEntry uniRefEntry) {
-        UniRefEntryConverter converter = new UniRefEntryConverter();
-        Entry xmlEntry = converter.toXml(uniRefEntry);
-        UniRefEntryLightConverter unirefLightConverter = new UniRefEntryLightConverter();
-        UniRefEntryLight entryLight = unirefLightConverter.fromXml(xmlEntry);
-        uniRefStoreClient.saveEntry(entryLight);
-    }
-
     @AfterEach
-    void tearDown() {
+    public void cleanUp() {
         asyncDownloadFileHandler.deleteAllFiles(ID);
-    }
-
-    @AfterAll
-    public void cleanUpData() throws Exception {
-        cleanUpFolder(idMappingAsyncConfig.getIdsFolder());
-        cleanUpFolder(idMappingAsyncConfig.getResultFolder());
-        downloadJobRepository.deleteAll();
-        this.amqpAdmin.purgeQueue(idMappingAsyncConfig.getRejectedQueue(), true);
-        this.amqpAdmin.purgeQueue(idMappingAsyncConfig.getDownloadQueue(), true);
-        this.amqpAdmin.purgeQueue(idMappingAsyncConfig.getRetryQueue(), true);
-        rabbitMQContainer.stop();
-        redisContainer.stop();
-    }
-
-    private void cleanUpFolder(String folder) throws IOException {
-        Files.list(Path.of(folder))
-                .forEach(
-                        path -> {
-                            try {
-                                Files.delete(path);
-                            } catch (IOException e) {
-                                throw new RuntimeException(e);
-                            }
-                        });
-    }
-
-    protected String cleanFormat(String format) {
-        StringBuilder result = new StringBuilder();
-        for (char c : format.toCharArray()) {
-            if (Character.isLetterOrDigit(c)) {
-                result.append(c);
-            }
-        }
-        return result.toString();
-    }
-
-    protected void cacheIdMappingJob(
-            String jobId, String to, JobStatus jobStatus, List<IdMappingStringPair> mappedIds) {
-        cacheIdMappingJob(jobId, to, jobStatus, mappedIds, List.of());
-    }
-
-    protected void cacheIdMappingJob(
-            String jobId,
-            String to,
-            JobStatus jobStatus,
-            List<IdMappingStringPair> mappedIds,
-            List<String> unMappedId) {
-        IdMappingJobRequest idMappingRequest = new IdMappingJobRequest();
-        idMappingRequest.setTo(to);
-
-        IdMappingResult idMappingResult =
-                IdMappingResult.builder().mappedIds(mappedIds).unmappedIds(unMappedId).build();
-
-        IdMappingJob idmappingJob =
-                IdMappingJob.builder()
-                        .jobStatus(jobStatus)
-                        .idMappingRequest(idMappingRequest)
-                        .idMappingResult(idMappingResult)
-                        .jobId(jobId)
-                        .build();
-        cacheService.put(jobId, idmappingJob);
     }
 
     @Test
@@ -775,7 +466,7 @@ public class IdMappingMessageConsumerIT {
             JobStatus jobStatus,
             long updateCount,
             long processedEntries) {
-        idMappingDownloadJobRepository.save(
+        downloadJobRepository.save(
                 IdMappingDownloadJob.builder()
                         .id(id)
                         .status(jobStatus)
@@ -783,37 +474,5 @@ public class IdMappingMessageConsumerIT {
                         .processedEntries(processedEntries)
                         .retried(retryCount)
                         .build());
-        System.out.println();
-    }
-
-    private Stream<Arguments> getAllUniProtKBFormats() {
-        return UniProtKBIdMappingDownloadRequestValidator.VALID_FORMATS.stream().map(Arguments::of);
-    }
-
-    private Stream<Arguments> getAllUniRefFormats() {
-        return UniRefIdMappingDownloadRequestValidator.VALID_FORMATS.stream().map(Arguments::of);
-    }
-
-    private Stream<Arguments> getAllUniParcFormats() {
-        return UniParcIdMappingDownloadRequestValidator.VALID_FORMATS.stream().map(Arguments::of);
-    }
-
-    private void validateSupportedRDFMediaTypes(String format, String text) {
-        switch (format) {
-            case UniProtMediaType.TURTLE_MEDIA_TYPE_VALUE:
-                assertTrue(text.contains("@prefix xsd: <http://www.w3.org/2001/XMLSchema#>"));
-                assertTrue(text.contains("<SAMPLE> rdf:type up:Protein ;"));
-                break;
-            case UniProtMediaType.N_TRIPLES_MEDIA_TYPE_VALUE:
-                assertTrue(text.contains("<http://purl.uniprot.org/uniprot/SAMPLE>"));
-                break;
-            case UniProtMediaType.RDF_MEDIA_TYPE_VALUE:
-                assertTrue(text.contains("<rdf:RDF"));
-                assertTrue(text.contains("<sample>text</sample>"));
-                assertTrue(text.contains("</rdf:RDF>"));
-                break;
-            default:
-                fail("Invalid SUPPORTED_RDF_MEDIA_TYPES");
-        }
     }
 }

--- a/async-download-rest/src/test/java/org/uniprot/api/async/download/messaging/consumer/uniparc/UniParcMessageConsumerIT.java
+++ b/async-download-rest/src/test/java/org/uniprot/api/async/download/messaging/consumer/uniparc/UniParcMessageConsumerIT.java
@@ -40,7 +40,6 @@ import org.uniprot.api.async.download.model.job.uniparc.UniParcDownloadJob;
 import org.uniprot.api.async.download.model.request.uniparc.UniParcDownloadRequest;
 import org.uniprot.api.common.repository.solrstream.FacetTupleStreamTemplate;
 import org.uniprot.api.common.repository.stream.common.TupleStreamTemplate;
-import org.uniprot.api.idmapping.common.service.TestConfig;
 import org.uniprot.api.rest.controller.ControllerITUtils;
 import org.uniprot.api.rest.download.model.JobStatus;
 import org.uniprot.api.rest.output.context.FileType;
@@ -58,7 +57,6 @@ import com.jayway.jsonpath.JsonPath;
 @ActiveProfiles(profiles = {"offline", "idmapping"})
 @ContextConfiguration(
         classes = {
-            TestConfig.class,
             UniParcDataStoreTestConfig.class,
             UniProtKBDataStoreTestConfig.class,
             AsyncDownloadRestApp.class,

--- a/async-download-rest/src/test/java/org/uniprot/api/async/download/messaging/consumer/uniprotkb/UniProtKBMessageConsumerIT.java
+++ b/async-download-rest/src/test/java/org/uniprot/api/async/download/messaging/consumer/uniprotkb/UniProtKBMessageConsumerIT.java
@@ -43,7 +43,6 @@ import org.uniprot.api.async.download.model.request.uniprotkb.UniProtKBDownloadR
 import org.uniprot.api.common.repository.solrstream.FacetTupleStreamTemplate;
 import org.uniprot.api.common.repository.stream.common.TupleStreamTemplate;
 import org.uniprot.api.common.repository.stream.store.uniprotkb.TaxonomyLineageRepository;
-import org.uniprot.api.idmapping.common.service.TestConfig;
 import org.uniprot.api.rest.controller.ControllerITUtils;
 import org.uniprot.api.rest.download.model.JobStatus;
 import org.uniprot.api.rest.output.context.FileType;
@@ -60,7 +59,6 @@ import com.jayway.jsonpath.JsonPath;
 @ActiveProfiles(profiles = {"offline", "idmapping"})
 @ContextConfiguration(
         classes = {
-            TestConfig.class,
             UniProtKBDataStoreTestConfig.class,
             UniProtKBDataStoreTestConfig.class,
             AsyncDownloadRestApp.class,

--- a/async-download-rest/src/test/java/org/uniprot/api/async/download/messaging/consumer/uniref/UniRefMessageConsumerIT.java
+++ b/async-download-rest/src/test/java/org/uniprot/api/async/download/messaging/consumer/uniref/UniRefMessageConsumerIT.java
@@ -37,7 +37,6 @@ import org.uniprot.api.async.download.model.job.uniref.UniRefDownloadJob;
 import org.uniprot.api.async.download.model.request.uniref.UniRefDownloadRequest;
 import org.uniprot.api.common.repository.solrstream.FacetTupleStreamTemplate;
 import org.uniprot.api.common.repository.stream.common.TupleStreamTemplate;
-import org.uniprot.api.idmapping.common.service.TestConfig;
 import org.uniprot.api.rest.controller.ControllerITUtils;
 import org.uniprot.api.rest.download.model.JobStatus;
 import org.uniprot.api.rest.output.context.FileType;
@@ -55,7 +54,6 @@ import com.jayway.jsonpath.JsonPath;
 @ActiveProfiles(profiles = {"offline", "idmapping"})
 @ContextConfiguration(
         classes = {
-            TestConfig.class,
             UniRefDataStoreTestConfig.class,
             UniProtKBDataStoreTestConfig.class,
             AsyncDownloadRestApp.class,

--- a/idmapping-common/src/test/java/org/uniprot/api/idmapping/common/TestConfig.java
+++ b/idmapping-common/src/test/java/org/uniprot/api/idmapping/common/TestConfig.java
@@ -1,4 +1,4 @@
-package org.uniprot.api.idmapping.common.service;
+package org.uniprot.api.idmapping.common;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -16,6 +16,8 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.uniprot.api.idmapping.common.service.IdMappingJobCacheService;
+import org.uniprot.api.idmapping.common.service.RedisTestContainer;
 import org.uniprot.api.idmapping.common.service.impl.RedisCacheMappingJobService;
 
 /**
@@ -37,7 +39,8 @@ public class TestConfig {
                                 + redisServer.getHost()
                                 + ":"
                                 + redisServer.getFirstMappedPort());
-        return Redisson.create(config);
+        RedissonClient client = Redisson.create(config);
+        return client;
     }
 
     @Bean

--- a/idmapping-common/src/test/java/org/uniprot/api/idmapping/common/service/IdMappingJobServiceTest.java
+++ b/idmapping-common/src/test/java/org/uniprot/api/idmapping/common/service/IdMappingJobServiceTest.java
@@ -39,6 +39,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.client.RestClientException;
 import org.uniprot.api.common.exception.ResourceNotFoundException;
 import org.uniprot.api.idmapping.common.IdMappingDataStoreTestConfig;
+import org.uniprot.api.idmapping.common.TestConfig;
 import org.uniprot.api.idmapping.common.model.IdMappingJob;
 import org.uniprot.api.idmapping.common.model.IdMappingResult;
 import org.uniprot.api.idmapping.common.request.IdMappingJobRequest;


### PR DESCRIPTION
1. move common code in IdMappingDownloadControllerIT and IdMappingMessageConsumerIT to base class 2. Move TestConfig.java to different package to avoid another instance of test container from async download rest 3. remove unneeded annotation @Containers and @TestContainers 4. Handle lifecycle of testcontainers manually