### PR TITLE
trigger refresh varnish from rest

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,7 +107,7 @@ k8s:docker-build-deploy:
     project: uniprot/deployment/unp.ci.api.k8s
     branch: main
   variables:
-    CI_PIPELINE_TASKS: 'build,upgrade'
+    CI_PIPELINE_TASKS: 'build,upgrade,refresh-varnish-cache'
     VERSION: '$UNIPROT_REST_VERSION'
     DC: 'DEV'
     K8S_ENV: 'dev'


### PR DESCRIPTION
While doing the nightly build we should reload/refresh varnish deployment as well. Otherwise, varnish doesn't update the IP of underlying service pod. See the changes in k8s project as well.