### PR TITLE
feat: TRM-34151: Add JSON based stream endpoint for precomputed annotations by proteome id

### DIFF
--- a/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/repository/store/UniProtStoreConfig.java
+++ b/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/repository/store/UniProtStoreConfig.java
@@ -4,7 +4,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.uniprot.api.common.repository.solrstream.FacetTupleStreamTemplate;
-import org.uniprot.api.rest.respository.RepositoryConfigProperties;
 import org.uniprot.api.rest.respository.UniProtKBRepositoryConfigProperties;
 import org.uniprot.core.uniprotkb.UniProtKBEntry;
 import org.uniprot.store.datastore.voldemort.VoldemortClient;

--- a/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationRequestConverterImpl.java
+++ b/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationRequestConverterImpl.java
@@ -9,11 +9,8 @@ import org.uniprot.api.rest.service.query.processor.UniProtQueryProcessorConfig;
 import org.uniprot.api.rest.service.request.BasicRequestConverter;
 import org.uniprot.api.rest.service.request.RequestConverterConfigProperties;
 import org.uniprot.api.rest.service.request.RequestConverterImpl;
-import org.uniprot.store.search.SolrQueryUtil;
 
 public class PrecomputedAnnotationRequestConverterImpl extends RequestConverterImpl {
-    private static final String TAXONOMY_ID = "taxonomy_id";
-
     private final BasicRequestConverter basicConverter;
 
     public PrecomputedAnnotationRequestConverterImpl(
@@ -44,7 +41,6 @@ public class PrecomputedAnnotationRequestConverterImpl extends RequestConverterI
         SolrRequest.SolrRequestBuilder builder =
                 basicConverter.createSearchSolrRequest(
                         precomputedAnnotationSearchByProteomeRequest);
-        builder.query(createQuery(precomputedAnnotationSearchByProteomeRequest));
         return builder.build();
     }
 
@@ -56,11 +52,5 @@ public class PrecomputedAnnotationRequestConverterImpl extends RequestConverterI
                 basicConverter.createStreamSolrRequest(
                         precomputedAnnotationStreamByProteomeRequest);
         return builder.build();
-    }
-
-    private String createQuery(PrecomputedAnnotationSearchByProteomeRequest request) {
-        String escapedTaxonomyId =
-                SolrQueryUtil.escapeSpecialCharacters(request.getTaxonomyId().strip());
-        return TAXONOMY_ID + ":" + escapedTaxonomyId;
     }
 }

--- a/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationRequestConverterImpl.java
+++ b/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationRequestConverterImpl.java
@@ -3,6 +3,7 @@ package org.uniprot.api.uniprotkb.common.service.precomputed;
 import org.uniprot.api.common.repository.search.SolrQueryConfig;
 import org.uniprot.api.common.repository.search.SolrRequest;
 import org.uniprot.api.rest.request.SearchRequest;
+import org.uniprot.api.rest.request.StreamRequest;
 import org.uniprot.api.rest.search.AbstractSolrSortClause;
 import org.uniprot.api.rest.service.query.processor.UniProtQueryProcessorConfig;
 import org.uniprot.api.rest.service.request.BasicRequestConverter;
@@ -47,7 +48,24 @@ public class PrecomputedAnnotationRequestConverterImpl extends RequestConverterI
         return builder.build();
     }
 
+    @Override
+    public SolrRequest createStreamSolrRequest(StreamRequest request) {
+        PrecomputedAnnotationStreamByProteomeRequest precomputedAnnotationStreamByProteomeRequest =
+                (PrecomputedAnnotationStreamByProteomeRequest) request;
+        SolrRequest.SolrRequestBuilder builder =
+                basicConverter.createStreamSolrRequest(
+                        precomputedAnnotationStreamByProteomeRequest);
+        builder.query(createQuery(precomputedAnnotationStreamByProteomeRequest));
+        return builder.build();
+    }
+
     private String createQuery(PrecomputedAnnotationSearchByProteomeRequest request) {
+        String escapedTaxonomyId =
+                SolrQueryUtil.escapeSpecialCharacters(request.getTaxonomyId().strip());
+        return TAXONOMY_ID + ":" + escapedTaxonomyId;
+    }
+
+    private String createQuery(PrecomputedAnnotationStreamByProteomeRequest request) {
         String escapedTaxonomyId =
                 SolrQueryUtil.escapeSpecialCharacters(request.getTaxonomyId().strip());
         return TAXONOMY_ID + ":" + escapedTaxonomyId;

--- a/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationRequestConverterImpl.java
+++ b/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationRequestConverterImpl.java
@@ -55,17 +55,10 @@ public class PrecomputedAnnotationRequestConverterImpl extends RequestConverterI
         SolrRequest.SolrRequestBuilder builder =
                 basicConverter.createStreamSolrRequest(
                         precomputedAnnotationStreamByProteomeRequest);
-        builder.query(createQuery(precomputedAnnotationStreamByProteomeRequest));
         return builder.build();
     }
 
     private String createQuery(PrecomputedAnnotationSearchByProteomeRequest request) {
-        String escapedTaxonomyId =
-                SolrQueryUtil.escapeSpecialCharacters(request.getTaxonomyId().strip());
-        return TAXONOMY_ID + ":" + escapedTaxonomyId;
-    }
-
-    private String createQuery(PrecomputedAnnotationStreamByProteomeRequest request) {
         String escapedTaxonomyId =
                 SolrQueryUtil.escapeSpecialCharacters(request.getTaxonomyId().strip());
         return TAXONOMY_ID + ":" + escapedTaxonomyId;

--- a/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationSearchByProteomeRequest.java
+++ b/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationSearchByProteomeRequest.java
@@ -1,5 +1,6 @@
 package org.uniprot.api.uniprotkb.common.service.precomputed;
 
+import static org.apache.commons.lang3.Validate.validState;
 import static org.uniprot.api.rest.openapi.OpenAPIConstants.*;
 
 import javax.validation.constraints.Max;
@@ -12,6 +13,7 @@ import org.uniprot.api.rest.request.SearchRequest;
 import org.uniprot.api.rest.request.UniProtKBRequestUtil;
 import org.uniprot.api.rest.validation.ValidReturnFields;
 import org.uniprot.api.rest.validation.ValidSolrSortFields;
+import org.uniprot.core.util.Utils;
 import org.uniprot.store.config.UniProtDataType;
 import org.uniprot.store.search.field.validator.FieldRegexConstants;
 
@@ -77,7 +79,8 @@ public class PrecomputedAnnotationSearchByProteomeRequest implements SearchReque
 
     @Override
     public String getQuery() {
-        return TAXONOMY_ID_STR + ":" + this.upId;
+        validState(Utils.notNullNotEmpty(taxonomyId), "Taxonomy Id should not be null or empty");
+        return TAXONOMY_ID_STR + ":" + taxonomyId;
     }
 
     public void setFormat(String format) {

--- a/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationStreamByProteomeRequest.java
+++ b/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationStreamByProteomeRequest.java
@@ -38,20 +38,6 @@ public class PrecomputedAnnotationStreamByProteomeRequest implements StreamReque
             message = "{search.invalid.upid.value}")
     private String upId;
 
-    @Parameter(description = ACCESSION_UNIPROTKB_DESCRIPTION, example = ACCESSION_UNIPROTKB_EXAMPLE)
-    @Pattern(
-            regexp = FieldRegexConstants.UNIPROTKB_ACCESSION_REGEX,
-            flags = {Pattern.Flag.CASE_INSENSITIVE},
-            message = "{search.invalid.accession.value}")
-    private String accession;
-
-    @Parameter(description = ID_UNIPARC_DESCRIPTION, example = ID_UNIPARC_EXAMPLE)
-    @Pattern(
-            regexp = FieldRegexConstants.UNIPARC_UPI_REGEX,
-            flags = {Pattern.Flag.CASE_INSENSITIVE},
-            message = "{search.invalid.upi.value}")
-    private String uniparc;
-
     @Parameter(description = ID_TAX_DESCRIPTION, example = ID_TAX_EXAMPLE)
     @Pattern(
             regexp = FieldRegexConstants.TAXONOMY_ID_REGEX,

--- a/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationStreamByProteomeRequest.java
+++ b/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationStreamByProteomeRequest.java
@@ -1,5 +1,6 @@
 package org.uniprot.api.uniprotkb.common.service.precomputed;
 
+import static org.apache.commons.lang3.Validate.validState;
 import static org.uniprot.api.rest.openapi.OpenAPIConstants.*;
 
 import javax.validation.constraints.NotNull;
@@ -57,10 +58,8 @@ public class PrecomputedAnnotationStreamByProteomeRequest implements StreamReque
 
     @Override
     public String getQuery() {
-        if (Utils.nullOrEmpty(taxonomyId)) {
-            throw new IllegalStateException("Taxonomy Id should not be null or empty");
-        }
-        return TAXONOMY_ID_STR + ":" + this.taxonomyId;
+        validState(Utils.notNullNotEmpty(taxonomyId), "Taxonomy Id should not be null or empty");
+        return TAXONOMY_ID_STR + ":" + taxonomyId;
     }
 
     public void setFormat(String format) {

--- a/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationStreamByProteomeRequest.java
+++ b/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationStreamByProteomeRequest.java
@@ -1,0 +1,80 @@
+package org.uniprot.api.uniprotkb.common.service.precomputed;
+
+import static org.uniprot.api.rest.openapi.OpenAPIConstants.*;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+import org.springdoc.api.annotations.ParameterObject;
+import org.uniprot.api.rest.request.BasicRequest;
+import org.uniprot.api.rest.request.StreamRequest;
+import org.uniprot.api.rest.request.UniProtKBRequestUtil;
+import org.uniprot.api.rest.validation.ValidReturnFields;
+import org.uniprot.api.rest.validation.ValidSolrSortFields;
+import org.uniprot.store.config.UniProtDataType;
+import org.uniprot.store.search.field.validator.FieldRegexConstants;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+@ParameterObject
+public class PrecomputedAnnotationStreamByProteomeRequest implements StreamRequest, BasicRequest {
+    private static final String TAXONOMY_ID_STR = "taxonomy_id";
+
+    @Parameter(description = DOWNLOAD_DESCRIPTION)
+    @Pattern(regexp = "^true$|^false$", message = "{search.uniprot.invalid.download}")
+    private String download;
+
+    @Parameter(
+            description = PROTEOME_UPID_UNIPARC_DESCRIPTION,
+            example = PROTEOME_UPID_UNIPARC_EXAMPLE)
+    @NotNull(message = "{search.required}")
+    @Pattern(
+            regexp = FieldRegexConstants.PROTEOME_ID_REGEX,
+            flags = {Pattern.Flag.CASE_INSENSITIVE},
+            message = "{search.invalid.upid.value}")
+    private String upId;
+
+    @Parameter(description = ACCESSION_UNIPROTKB_DESCRIPTION, example = ACCESSION_UNIPROTKB_EXAMPLE)
+    @Pattern(
+            regexp = FieldRegexConstants.UNIPROTKB_ACCESSION_REGEX,
+            flags = {Pattern.Flag.CASE_INSENSITIVE},
+            message = "{search.invalid.accession.value}")
+    private String accession;
+
+    @Parameter(description = ID_UNIPARC_DESCRIPTION, example = ID_UNIPARC_EXAMPLE)
+    @Pattern(
+            regexp = FieldRegexConstants.UNIPARC_UPI_REGEX,
+            flags = {Pattern.Flag.CASE_INSENSITIVE},
+            message = "{search.invalid.upi.value}")
+    private String uniparc;
+
+    @Parameter(description = ID_TAX_DESCRIPTION, example = ID_TAX_EXAMPLE)
+    @Pattern(
+            regexp = FieldRegexConstants.TAXONOMY_ID_REGEX,
+            message = "{search.taxonomy.invalid.id}")
+    private String taxonomyId;
+
+    @Parameter(description = SORT_DESCRIPTION, example = "accession asc")
+    @ValidSolrSortFields(uniProtDataType = UniProtDataType.PRECOMPUTED_ANNOTATION)
+    private String sort;
+
+    @Parameter(hidden = true)
+    @ValidReturnFields(uniProtDataType = UniProtDataType.PRECOMPUTED_ANNOTATION)
+    private String fields;
+
+    @Parameter(hidden = true)
+    private String format;
+
+    @Override
+    public String getQuery() {
+        return TAXONOMY_ID_STR + ":" + this.upId;
+    }
+
+    public void setFormat(String format) {
+        this.format = UniProtKBRequestUtil.parseFormat(format);
+    }
+}

--- a/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationStreamByProteomeRequest.java
+++ b/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationStreamByProteomeRequest.java
@@ -6,11 +6,11 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
 import org.springdoc.api.annotations.ParameterObject;
-import org.uniprot.api.rest.request.BasicRequest;
 import org.uniprot.api.rest.request.StreamRequest;
 import org.uniprot.api.rest.request.UniProtKBRequestUtil;
 import org.uniprot.api.rest.validation.ValidReturnFields;
 import org.uniprot.api.rest.validation.ValidSolrSortFields;
+import org.uniprot.core.util.Utils;
 import org.uniprot.store.config.UniProtDataType;
 import org.uniprot.store.search.field.validator.FieldRegexConstants;
 
@@ -21,7 +21,7 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(callSuper = false)
 @ParameterObject
-public class PrecomputedAnnotationStreamByProteomeRequest implements StreamRequest, BasicRequest {
+public class PrecomputedAnnotationStreamByProteomeRequest implements StreamRequest {
     private static final String TAXONOMY_ID_STR = "taxonomy_id";
 
     @Parameter(description = DOWNLOAD_DESCRIPTION)
@@ -57,7 +57,10 @@ public class PrecomputedAnnotationStreamByProteomeRequest implements StreamReque
 
     @Override
     public String getQuery() {
-        return TAXONOMY_ID_STR + ":" + this.upId;
+        if (Utils.nullOrEmpty(taxonomyId)) {
+            throw new IllegalStateException("Taxonomy Id should not be null or empty");
+        }
+        return TAXONOMY_ID_STR + ":" + this.taxonomyId;
     }
 
     public void setFormat(String format) {

--- a/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationStreamConfig.java
+++ b/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationStreamConfig.java
@@ -1,0 +1,91 @@
+package org.uniprot.api.uniprotkb.common.service.precomputed;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import org.apache.solr.client.solrj.SolrClient;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.uniprot.api.common.repository.search.SolrRequestConverter;
+import org.uniprot.api.common.repository.stream.common.TupleStreamTemplate;
+import org.uniprot.api.common.repository.stream.document.TupleStreamDocumentIdStream;
+import org.uniprot.api.common.repository.stream.store.StoreStreamer;
+import org.uniprot.api.common.repository.stream.store.StoreStreamerConfig;
+import org.uniprot.api.common.repository.stream.store.StreamerConfigProperties;
+import org.uniprot.api.rest.respository.RepositoryConfig;
+import org.uniprot.api.uniprotkb.common.repository.store.precomputed.PrecomputedAnnotationStoreClient;
+import org.uniprot.core.uniprotkb.UniProtKBEntry;
+
+import lombok.extern.slf4j.Slf4j;
+import net.jodah.failsafe.RetryPolicy;
+
+@Configuration
+@Import(RepositoryConfig.class)
+@Slf4j
+public class PrecomputedAnnotationStreamConfig {
+    @Bean
+    public StoreStreamer<UniProtKBEntry> precomputedAnnotationStoreStreamer(
+            StoreStreamerConfig<UniProtKBEntry> precomputedAnnotationStoreStreamerConfig) {
+        return new StoreStreamer<>(precomputedAnnotationStoreStreamerConfig);
+    }
+
+    @Bean("precomputedAnnotationTupleStream")
+    public TupleStreamTemplate tupleStreamTemplate(
+            @Qualifier("precomputedAnnotationStreamerConfigProperties")
+                    StreamerConfigProperties configProperties,
+            @Qualifier("uniProtKBSolrClient") SolrClient solrClient,
+            SolrRequestConverter requestConverter) {
+        return TupleStreamTemplate.builder()
+                .streamConfig(configProperties)
+                .solrClient(solrClient)
+                .solrRequestConverter(requestConverter)
+                .build();
+    }
+
+    @Bean(name = "precomputedAnnotationStreamerConfigProperties")
+    @ConfigurationProperties(prefix = "streamer.precomputedannotation")
+    public StreamerConfigProperties resultsConfigProperties() {
+        //        TODO why do we have to expand like this?
+        //        StreamerConfigProperties b = new StreamerConfigProperties();
+        //        return b;
+        return new StreamerConfigProperties();
+    }
+
+    @Bean("precomputedAnnotationTupleStreamDocumentIdStream")
+    public TupleStreamDocumentIdStream documentIdStream(
+            @Qualifier("precomputedAnnotationTupleStream") TupleStreamTemplate tupleStreamTemplate,
+            @Qualifier("precomputedAnnotationStreamerConfigProperties")
+                    StreamerConfigProperties streamConfig) {
+        return TupleStreamDocumentIdStream.builder()
+                .tupleStreamTemplate(tupleStreamTemplate)
+                .streamConfig(streamConfig)
+                .build();
+    }
+
+    @Bean
+    public StoreStreamerConfig<UniProtKBEntry> precomputedAnnotationStoreStreamerConfig(
+            PrecomputedAnnotationStoreClient precomputedAnnotationStoreClient,
+            @Qualifier("precomputedAnnotationTupleStream") TupleStreamTemplate tupleStreamTemplate,
+            @Qualifier("precomputedAnnotationStreamerConfigProperties")
+                    StreamerConfigProperties streamConfig,
+            @Qualifier("precomputedAnnotationTupleStreamDocumentIdStream")
+                    TupleStreamDocumentIdStream documentIdStream) {
+
+        RetryPolicy<Object> storeRetryPolicy =
+                new RetryPolicy<>()
+                        .handle(IOException.class)
+                        .withDelay(Duration.ofMillis(streamConfig.getStoreFetchRetryDelayMillis()))
+                        .withMaxRetries(streamConfig.getStoreFetchMaxRetries());
+
+        return StoreStreamerConfig.<UniProtKBEntry>builder()
+                .streamConfig(streamConfig)
+                .storeClient(precomputedAnnotationStoreClient)
+                .tupleStreamTemplate(tupleStreamTemplate)
+                .storeFetchRetryPolicy(storeRetryPolicy)
+                .documentIdStream(documentIdStream)
+                .build();
+    }
+}

--- a/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationStreamConfig.java
+++ b/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationStreamConfig.java
@@ -48,9 +48,6 @@ public class PrecomputedAnnotationStreamConfig {
     @Bean(name = "precomputedAnnotationStreamerConfigProperties")
     @ConfigurationProperties(prefix = "streamer.precomputedannotation")
     public StreamerConfigProperties resultsConfigProperties() {
-        //        TODO why do we have to expand like this?
-        //        StreamerConfigProperties b = new StreamerConfigProperties();
-        //        return b;
         return new StreamerConfigProperties();
     }
 

--- a/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedUniProtKBEntryService.java
+++ b/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedUniProtKBEntryService.java
@@ -1,6 +1,10 @@
 package org.uniprot.api.uniprotkb.common.service.precomputed;
 
+import static org.uniprot.api.rest.output.UniProtMediaType.LIST_MEDIA_TYPE_VALUE;
+
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Import;
@@ -8,11 +12,16 @@ import org.springframework.stereotype.Service;
 import org.uniprot.api.common.exception.ResourceNotFoundException;
 import org.uniprot.api.common.repository.search.QueryResult;
 import org.uniprot.api.common.repository.search.SolrRequest;
+import org.uniprot.api.common.repository.stream.document.TupleStreamDocumentIdStream;
+import org.uniprot.api.common.repository.stream.store.StoreRequest;
+import org.uniprot.api.common.repository.stream.store.StoreStreamer;
 import org.uniprot.api.rest.service.request.RequestConverter;
 import org.uniprot.api.uniprotkb.common.repository.search.PrecomputedAnnotationRepository;
 import org.uniprot.api.uniprotkb.common.repository.search.PrecomputedAnnotationSolrQueryConfig;
 import org.uniprot.api.uniprotkb.common.repository.store.precomputed.PrecomputedAnnotationStoreClient;
 import org.uniprot.core.uniprotkb.UniProtKBEntry;
+import org.uniprot.core.uniprotkb.UniProtKBEntryType;
+import org.uniprot.core.uniprotkb.impl.UniProtKBEntryBuilder;
 import org.uniprot.store.search.document.precomputed.PrecomputedAnnotationDocument;
 
 @Service
@@ -22,16 +31,24 @@ public class PrecomputedUniProtKBEntryService {
     private final PrecomputedAnnotationRepository repository;
     private final ProteomeTaxonomyResolver proteomeTaxonomyResolver;
     private final RequestConverter requestConverter;
+    private final StoreStreamer<UniProtKBEntry> storeStreamer;
+    private final TupleStreamDocumentIdStream solrIdStreamer;
 
     public PrecomputedUniProtKBEntryService(
             PrecomputedAnnotationStoreClient storeClient,
             PrecomputedAnnotationRepository repository,
             ProteomeTaxonomyResolver proteomeTaxonomyResolver,
-            @Qualifier("precomputedAnnotationRequestConverter") RequestConverter requestConverter) {
+            @Qualifier("precomputedAnnotationRequestConverter") RequestConverter requestConverter,
+            @Qualifier("precomputedAnnotationStoreStreamer")
+                    StoreStreamer<UniProtKBEntry> storeStreamer,
+            @Qualifier("precomputedAnnotationTupleStreamDocumentIdStream")
+                    TupleStreamDocumentIdStream solrIdStreamer) {
         this.storeClient = storeClient;
         this.repository = repository;
         this.proteomeTaxonomyResolver = proteomeTaxonomyResolver;
         this.requestConverter = requestConverter;
+        this.storeStreamer = storeStreamer;
+        this.solrIdStreamer = solrIdStreamer;
     }
 
     public UniProtKBEntry getPrecomputedUniProtKBEntry(String upi, String taxId) {
@@ -63,5 +80,27 @@ public class PrecomputedUniProtKBEntryService {
                 .suggestions(results.getSuggestions())
                 .warnings(results.getWarnings())
                 .build();
+    }
+
+    public Stream<UniProtKBEntry> stream(PrecomputedAnnotationStreamByProteomeRequest request) {
+        String taxonomyId = proteomeTaxonomyResolver.findTaxonomyIdByUpId(request.getUpId());
+        request.setTaxonomyId(taxonomyId);
+
+        SolrRequest solrRequest = requestConverter.createStreamSolrRequest(request);
+        if (LIST_MEDIA_TYPE_VALUE.equals(request.getFormat())) {
+            return this.solrIdStreamer
+                    .fetchIds(solrRequest)
+                    .map(this::mapToThinEntry)
+                    .filter(Objects::nonNull);
+        } else {
+            StoreRequest storeRequest = StoreRequest.builder().fields(request.getFields()).build();
+            return this.storeStreamer.idsToStoreStream(solrRequest, storeRequest);
+        }
+    }
+
+    protected UniProtKBEntry mapToThinEntry(String accession) {
+        UniProtKBEntryBuilder builder =
+                new UniProtKBEntryBuilder(accession, accession, UniProtKBEntryType.SWISSPROT);
+        return builder.build();
     }
 }

--- a/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedUniProtKBEntryService.java
+++ b/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedUniProtKBEntryService.java
@@ -82,7 +82,7 @@ public class PrecomputedUniProtKBEntryService {
                 .build();
     }
 
-    public Stream<UniProtKBEntry> stream(PrecomputedAnnotationStreamByProteomeRequest request) {
+    public Stream<UniProtKBEntry> streamByProteomeId(PrecomputedAnnotationStreamByProteomeRequest request) {
         String taxonomyId = proteomeTaxonomyResolver.findTaxonomyIdByUpId(request.getUpId());
         request.setTaxonomyId(taxonomyId);
 

--- a/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedUniProtKBEntryService.java
+++ b/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedUniProtKBEntryService.java
@@ -82,7 +82,8 @@ public class PrecomputedUniProtKBEntryService {
                 .build();
     }
 
-    public Stream<UniProtKBEntry> streamByProteomeId(PrecomputedAnnotationStreamByProteomeRequest request) {
+    public Stream<UniProtKBEntry> streamByProteomeId(
+            PrecomputedAnnotationStreamByProteomeRequest request) {
         String taxonomyId = proteomeTaxonomyResolver.findTaxonomyIdByUpId(request.getUpId());
         request.setTaxonomyId(taxonomyId);
 

--- a/uniprotkb-common/src/test/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationRequestConverterImplTest.java
+++ b/uniprotkb-common/src/test/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationRequestConverterImplTest.java
@@ -33,7 +33,8 @@ class PrecomputedAnnotationRequestConverterImplTest {
     @Test
     void createsStreamSolrQueryFromResolvedTaxonomyId() {
         PrecomputedAnnotationRequestConverterImpl converter = converter();
-        PrecomputedAnnotationStreamByProteomeRequest request = new PrecomputedAnnotationStreamByProteomeRequest();
+        PrecomputedAnnotationStreamByProteomeRequest request =
+                new PrecomputedAnnotationStreamByProteomeRequest();
         request.setTaxonomyId("9606");
         request.setSort("accession desc");
 

--- a/uniprotkb-common/src/test/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationRequestConverterImplTest.java
+++ b/uniprotkb-common/src/test/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedAnnotationRequestConverterImplTest.java
@@ -31,6 +31,23 @@ class PrecomputedAnnotationRequestConverterImplTest {
     }
 
     @Test
+    void createsStreamSolrQueryFromResolvedTaxonomyId() {
+        PrecomputedAnnotationRequestConverterImpl converter = converter();
+        PrecomputedAnnotationStreamByProteomeRequest request = new PrecomputedAnnotationStreamByProteomeRequest();
+        request.setTaxonomyId("9606");
+        request.setSort("accession desc");
+
+        SolrRequest solrRequest = converter.createStreamSolrRequest(request);
+
+        assertEquals("taxonomy_id:9606", solrRequest.getQuery());
+        assertEquals("accession uniparc taxonomy_id", solrRequest.getQueryField());
+        assertEquals(100, solrRequest.getRows());
+        assertEquals(Integer.MAX_VALUE, solrRequest.getTotalRows());
+        assertEquals("accession", solrRequest.getSorts().get(0).getItem());
+        assertEquals(SolrQuery.ORDER.desc, solrRequest.getSorts().get(0).getOrder());
+    }
+
+    @Test
     void ignoresOtherFieldsAndUsesResolvedTaxonomyId() {
         PrecomputedAnnotationRequestConverterImpl converter = converter();
         PrecomputedAnnotationSearchByProteomeRequest request =

--- a/uniprotkb-common/src/test/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedUniProtKBEntryServiceTest.java
+++ b/uniprotkb-common/src/test/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedUniProtKBEntryServiceTest.java
@@ -1,14 +1,5 @@
 package org.uniprot.api.uniprotkb.common.service.precomputed;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -28,7 +19,17 @@ import org.uniprot.core.uniprotkb.UniProtKBEntryType;
 import org.uniprot.core.uniprotkb.impl.UniProtKBEntryBuilder;
 import org.uniprot.store.search.document.precomputed.PrecomputedAnnotationDocument;
 
-// TODO
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.uniprot.api.rest.output.UniProtMediaType.LIST_MEDIA_TYPE_VALUE;
+
 @ExtendWith(MockitoExtension.class)
 class PrecomputedUniProtKBEntryServiceTest {
     @Mock private PrecomputedAnnotationStoreClient storeClient;
@@ -130,6 +131,61 @@ class PrecomputedUniProtKBEntryServiceTest {
 
         assertEquals(List.of(entry), result.getContent().collect(Collectors.toList()));
         verify(storeClient).getEntries(List.of("P12345"));
+    }
+
+    @Test
+    void streamInNonListFormatWithStoreStreamerBeingCalled() {
+        String acc1 = "P56789";
+        UniProtKBEntry entry1 = new UniProtKBEntryBuilder(acc1, acc1, UniProtKBEntryType.SWISSPROT).build();
+
+        PrecomputedAnnotationStreamByProteomeRequest request = new PrecomputedAnnotationStreamByProteomeRequest();
+        request.setFormat(APPLICATION_JSON_VALUE);
+        request.setUpId("UP000000000");
+
+        SolrRequest solrRequest = SolrRequest.builder().query("taxonomy_id:9606").rows(100).build();
+
+        when(proteomeTaxonomyResolver.findTaxonomyIdByUpId("UP000000000")).thenReturn("9606");
+        when(requestConverter.createStreamSolrRequest(request)).thenReturn(solrRequest);
+        when(storeStreamer.idsToStoreStream(any(), any())).thenReturn(Stream.of(entry1));
+
+        Stream<UniProtKBEntry> result = service().streamByProteomeId(request);
+
+        List<UniProtKBEntry> entries = result.toList();
+        verify(proteomeTaxonomyResolver).findTaxonomyIdByUpId("UP000000000");
+        verify(requestConverter).createStreamSolrRequest(request);
+        verify(storeStreamer, times(1)).idsToStoreStream(any(), any());
+        assertEquals(1, entries.size());
+        assertEquals(entry1, entries.get(0));
+    }
+
+    @Test
+    void streamInListFormatWithSolrIdStreamerBeingCalled() {
+        String acc1 = "Q12345";
+        String acc2 = "Q54321";
+        UniProtKBEntry entry1 =
+                new UniProtKBEntryBuilder(acc1, acc1, UniProtKBEntryType.SWISSPROT).build();
+        UniProtKBEntry entry2 =
+                new UniProtKBEntryBuilder(acc2, acc2, UniProtKBEntryType.SWISSPROT).build();
+
+        PrecomputedAnnotationStreamByProteomeRequest request = new PrecomputedAnnotationStreamByProteomeRequest();
+        request.setFormat(LIST_MEDIA_TYPE_VALUE);
+        request.setUpId("UP000000000");
+
+        SolrRequest solrRequest = SolrRequest.builder().query("taxonomy_id:9606").rows(100).build();
+
+        when(proteomeTaxonomyResolver.findTaxonomyIdByUpId("UP000000000")).thenReturn("9606");
+        when(requestConverter.createStreamSolrRequest(request)).thenReturn(solrRequest);
+        when(solrIdStreamer.fetchIds(solrRequest)).thenReturn(Stream.of(acc1, acc2));
+
+        Stream<UniProtKBEntry> result = service().streamByProteomeId(request);
+
+        List<UniProtKBEntry> entries = result.toList();
+        verify(proteomeTaxonomyResolver).findTaxonomyIdByUpId("UP000000000");
+        verify(requestConverter).createStreamSolrRequest(request);
+        verify(solrIdStreamer, times(1)).fetchIds(any());
+        assertEquals(2, entries.size());
+        assertEquals(entry1, entries.get(0));
+        assertEquals(entry2, entries.get(1));
     }
 
     private PrecomputedUniProtKBEntryService service() {

--- a/uniprotkb-common/src/test/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedUniProtKBEntryServiceTest.java
+++ b/uniprotkb-common/src/test/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedUniProtKBEntryServiceTest.java
@@ -18,6 +18,8 @@ import org.uniprot.api.common.repository.search.QueryResult;
 import org.uniprot.api.common.repository.search.SolrRequest;
 import org.uniprot.api.common.repository.search.page.impl.CursorPage;
 import org.uniprot.api.common.repository.search.suggestion.Suggestion;
+import org.uniprot.api.common.repository.stream.document.TupleStreamDocumentIdStream;
+import org.uniprot.api.common.repository.stream.store.StoreStreamer;
 import org.uniprot.api.rest.service.request.RequestConverter;
 import org.uniprot.api.uniprotkb.common.repository.search.PrecomputedAnnotationRepository;
 import org.uniprot.api.uniprotkb.common.repository.store.precomputed.PrecomputedAnnotationStoreClient;
@@ -32,6 +34,8 @@ class PrecomputedUniProtKBEntryServiceTest {
     @Mock private PrecomputedAnnotationRepository repository;
     @Mock private ProteomeTaxonomyResolver proteomeTaxonomyResolver;
     @Mock private RequestConverter requestConverter;
+    @Mock private StoreStreamer<UniProtKBEntry> storeStreamer;
+    @Mock private TupleStreamDocumentIdStream solrIdStreamer;
 
     @Test
     void searchReturnsStoreEntriesForPrecomputedDocuments() {
@@ -129,7 +133,12 @@ class PrecomputedUniProtKBEntryServiceTest {
 
     private PrecomputedUniProtKBEntryService service() {
         return new PrecomputedUniProtKBEntryService(
-                storeClient, repository, proteomeTaxonomyResolver, requestConverter);
+                storeClient,
+                repository,
+                proteomeTaxonomyResolver,
+                requestConverter,
+                storeStreamer,
+                solrIdStreamer);
     }
 
     private static PrecomputedAnnotationDocument document(String accession) {

--- a/uniprotkb-common/src/test/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedUniProtKBEntryServiceTest.java
+++ b/uniprotkb-common/src/test/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedUniProtKBEntryServiceTest.java
@@ -28,6 +28,7 @@ import org.uniprot.core.uniprotkb.UniProtKBEntryType;
 import org.uniprot.core.uniprotkb.impl.UniProtKBEntryBuilder;
 import org.uniprot.store.search.document.precomputed.PrecomputedAnnotationDocument;
 
+// TODO
 @ExtendWith(MockitoExtension.class)
 class PrecomputedUniProtKBEntryServiceTest {
     @Mock private PrecomputedAnnotationStoreClient storeClient;

--- a/uniprotkb-common/src/test/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedUniProtKBEntryServiceTest.java
+++ b/uniprotkb-common/src/test/java/org/uniprot/api/uniprotkb/common/service/precomputed/PrecomputedUniProtKBEntryServiceTest.java
@@ -1,5 +1,16 @@
 package org.uniprot.api.uniprotkb.common.service.precomputed;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.uniprot.api.rest.output.UniProtMediaType.LIST_MEDIA_TYPE_VALUE;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -18,17 +29,6 @@ import org.uniprot.core.uniprotkb.UniProtKBEntry;
 import org.uniprot.core.uniprotkb.UniProtKBEntryType;
 import org.uniprot.core.uniprotkb.impl.UniProtKBEntryBuilder;
 import org.uniprot.store.search.document.precomputed.PrecomputedAnnotationDocument;
-
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-import static org.uniprot.api.rest.output.UniProtMediaType.LIST_MEDIA_TYPE_VALUE;
 
 @ExtendWith(MockitoExtension.class)
 class PrecomputedUniProtKBEntryServiceTest {
@@ -136,9 +136,11 @@ class PrecomputedUniProtKBEntryServiceTest {
     @Test
     void streamInNonListFormatWithStoreStreamerBeingCalled() {
         String acc1 = "P56789";
-        UniProtKBEntry entry1 = new UniProtKBEntryBuilder(acc1, acc1, UniProtKBEntryType.SWISSPROT).build();
+        UniProtKBEntry entry1 =
+                new UniProtKBEntryBuilder(acc1, acc1, UniProtKBEntryType.SWISSPROT).build();
 
-        PrecomputedAnnotationStreamByProteomeRequest request = new PrecomputedAnnotationStreamByProteomeRequest();
+        PrecomputedAnnotationStreamByProteomeRequest request =
+                new PrecomputedAnnotationStreamByProteomeRequest();
         request.setFormat(APPLICATION_JSON_VALUE);
         request.setUpId("UP000000000");
 
@@ -167,7 +169,8 @@ class PrecomputedUniProtKBEntryServiceTest {
         UniProtKBEntry entry2 =
                 new UniProtKBEntryBuilder(acc2, acc2, UniProtKBEntryType.SWISSPROT).build();
 
-        PrecomputedAnnotationStreamByProteomeRequest request = new PrecomputedAnnotationStreamByProteomeRequest();
+        PrecomputedAnnotationStreamByProteomeRequest request =
+                new PrecomputedAnnotationStreamByProteomeRequest();
         request.setFormat(LIST_MEDIA_TYPE_VALUE);
         request.setUpId("UP000000000");
 

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBController.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBController.java
@@ -147,7 +147,7 @@ public class PrecomputedUniProtKBController extends BasicSearchController<UniPro
 
     @GetMapping(
             value = "/proteome/{upId}/stream",
-            produces = {APPLICATION_JSON_VALUE})
+            produces = {APPLICATION_JSON_VALUE, LIST_MEDIA_TYPE_VALUE})
     @Operation(hidden = true)
     public DeferredResult<ResponseEntity<MessageConverterContext<UniProtKBEntry>>>
             streamByProteomeId(

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBController.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBController.java
@@ -1,10 +1,20 @@
 package org.uniprot.api.uniprotkb.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
+import static org.uniprot.api.rest.openapi.OpenAPIConstants.*;
+import static org.uniprot.api.rest.output.UniProtMediaType.*;
+import static org.uniprot.api.uniprotkb.controller.PrecomputedUniProtKBController.PRECOMPUTED_ANNOTATION_RESOURCE;
+import static org.uniprot.api.uniprotkb.controller.UniProtKBController.UNIPROTKB_RESOURCE;
+import static org.uniprot.store.search.field.validator.FieldRegexConstants.TAXONOMY_ID_REGEX;
+
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
+import javax.validation.constraints.Pattern;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.MediaType;
@@ -25,19 +35,11 @@ import org.uniprot.core.uniprotkb.UniProtKBEntry;
 import org.uniprot.core.xml.jaxb.uniprot.Entry;
 import org.uniprot.store.search.field.validator.FieldRegexConstants;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.validation.Valid;
-import javax.validation.constraints.Pattern;
-import java.util.Optional;
-
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
-import static org.uniprot.api.rest.openapi.OpenAPIConstants.*;
-import static org.uniprot.api.rest.output.UniProtMediaType.*;
-import static org.uniprot.api.uniprotkb.controller.PrecomputedUniProtKBController.PRECOMPUTED_ANNOTATION_RESOURCE;
-import static org.uniprot.api.uniprotkb.controller.UniProtKBController.UNIPROTKB_RESOURCE;
-import static org.uniprot.store.search.field.validator.FieldRegexConstants.TAXONOMY_ID_REGEX;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 @RestController
 @RequestMapping(value = PRECOMPUTED_ANNOTATION_RESOURCE)
@@ -147,19 +149,21 @@ public class PrecomputedUniProtKBController extends BasicSearchController<UniPro
             value = "/proteome/{upId}/stream",
             produces = {APPLICATION_JSON_VALUE})
     @Operation(hidden = true)
-    public DeferredResult<ResponseEntity<MessageConverterContext<UniProtKBEntry>>> streamByProteomeId(
-            @PathVariable("upId")
-                    @Pattern(
-                            regexp = FieldRegexConstants.PROTEOME_ID_REGEX,
-                            flags = {Pattern.Flag.CASE_INSENSITIVE},
-                            message = "{search.invalid.upid.value}")
-                    @Parameter(
-                            description = PROTEOME_UPID_UNIPARC_DESCRIPTION,
-                            example = PROTEOME_UPID_UNIPARC_EXAMPLE,
-                            required = true)
-                    String upId,
-            @Valid @ModelAttribute PrecomputedAnnotationStreamByProteomeRequest streamRequest,
-            HttpServletRequest request) {
+    public DeferredResult<ResponseEntity<MessageConverterContext<UniProtKBEntry>>>
+            streamByProteomeId(
+                    @PathVariable("upId")
+                            @Pattern(
+                                    regexp = FieldRegexConstants.PROTEOME_ID_REGEX,
+                                    flags = {Pattern.Flag.CASE_INSENSITIVE},
+                                    message = "{search.invalid.upid.value}")
+                            @Parameter(
+                                    description = PROTEOME_UPID_UNIPARC_DESCRIPTION,
+                                    example = PROTEOME_UPID_UNIPARC_EXAMPLE,
+                                    required = true)
+                            String upId,
+                    @Valid @ModelAttribute
+                            PrecomputedAnnotationStreamByProteomeRequest streamRequest,
+                    HttpServletRequest request) {
 
         streamRequest.setUpId(upId);
         MediaType contentType = getAcceptHeader(request);

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBController.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBController.java
@@ -2,7 +2,7 @@ package org.uniprot.api.uniprotkb.controller;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.uniprot.api.rest.openapi.OpenAPIConstants.*;
-import static org.uniprot.api.uniprotkb.controller.PrecomputedUniProtKBController.*;
+import static org.uniprot.api.uniprotkb.controller.PrecomputedUniProtKBController.PRECOMPUTED_ANNOTATION_RESOURCE;
 import static org.uniprot.api.uniprotkb.controller.UniProtKBController.UNIPROTKB_RESOURCE;
 import static org.uniprot.store.search.field.validator.FieldRegexConstants.TAXONOMY_ID_REGEX;
 
@@ -20,12 +20,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.async.DeferredResult;
 import org.uniprot.api.common.concurrency.Gatekeeper;
 import org.uniprot.api.common.repository.search.QueryResult;
 import org.uniprot.api.rest.controller.BasicSearchController;
 import org.uniprot.api.rest.output.context.MessageConverterContext;
 import org.uniprot.api.rest.output.context.MessageConverterContextFactory;
 import org.uniprot.api.uniprotkb.common.service.precomputed.PrecomputedAnnotationSearchByProteomeRequest;
+import org.uniprot.api.uniprotkb.common.service.precomputed.PrecomputedAnnotationStreamByProteomeRequest;
 import org.uniprot.api.uniprotkb.common.service.precomputed.PrecomputedUniProtKBEntryService;
 import org.uniprot.core.uniprotkb.UniProtKBEntry;
 import org.uniprot.store.search.field.validator.FieldRegexConstants;
@@ -37,6 +39,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 @RequestMapping(value = PRECOMPUTED_ANNOTATION_RESOURCE)
 @Validated
 public class PrecomputedUniProtKBController extends BasicSearchController<UniProtKBEntry> {
+    private static final String DATA_TYPE = "uniprotkb";
     static final String PRECOMPUTED_ANNOTATION_RESOURCE = UNIPROTKB_RESOURCE + "/precomputed";
 
     private final PrecomputedUniProtKBEntryService precomputedUniProtKBEntryService;
@@ -108,6 +111,47 @@ public class PrecomputedUniProtKBController extends BasicSearchController<UniPro
         QueryResult<UniProtKBEntry> results =
                 precomputedUniProtKBEntryService.search(searchRequest);
         return super.getSearchResponse(results, searchRequest.getFields(), request, response);
+    }
+
+    @GetMapping(
+            value = "/proteome/{upId}/stream",
+            produces = {APPLICATION_JSON_VALUE})
+    @Operation(hidden = true)
+    public DeferredResult<ResponseEntity<MessageConverterContext<UniProtKBEntry>>> stream(
+            @PathVariable("upId")
+                    @Pattern(
+                            regexp = FieldRegexConstants.PROTEOME_ID_REGEX,
+                            flags = {Pattern.Flag.CASE_INSENSITIVE},
+                            message = "{search.invalid.upid.value}")
+                    @Parameter(
+                            description = PROTEOME_UPID_UNIPARC_DESCRIPTION,
+                            example = PROTEOME_UPID_UNIPARC_EXAMPLE,
+                            required = true)
+                    String upId,
+            @Valid @ModelAttribute PrecomputedAnnotationStreamByProteomeRequest streamRequest,
+            HttpServletRequest request) {
+
+        streamRequest.setUpId(upId);
+        MediaType contentType = getAcceptHeader(request);
+        setBasicRequestFormat(streamRequest, request);
+
+        //        Optional<String> acceptedRdfContentType = getAcceptedRdfContentType(request);
+        //        if (acceptedRdfContentType.isPresent()) {
+        //            return super.streamRdf(
+        //                    () ->
+        //                            precomputedUniProtKBEntryService.streamRdf(
+        //                                    streamRequest, DATA_TYPE,
+        // acceptedRdfContentType.get()),
+        //                    streamRequest,
+        //                    contentType,
+        //                    request);
+        //        } else {}
+
+        return super.stream(
+                () -> precomputedUniProtKBEntryService.stream(streamRequest),
+                streamRequest,
+                contentType,
+                request);
     }
 
     @Override

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBController.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBController.java
@@ -117,7 +117,7 @@ public class PrecomputedUniProtKBController extends BasicSearchController<UniPro
             value = "/proteome/{upId}/stream",
             produces = {APPLICATION_JSON_VALUE})
     @Operation(hidden = true)
-    public DeferredResult<ResponseEntity<MessageConverterContext<UniProtKBEntry>>> stream(
+    public DeferredResult<ResponseEntity<MessageConverterContext<UniProtKBEntry>>> streamByProteomeId(
             @PathVariable("upId")
                     @Pattern(
                             regexp = FieldRegexConstants.PROTEOME_ID_REGEX,
@@ -135,6 +135,7 @@ public class PrecomputedUniProtKBController extends BasicSearchController<UniPro
         MediaType contentType = getAcceptHeader(request);
         setBasicRequestFormat(streamRequest, request);
 
+        // TODO cleanup later
         //        Optional<String> acceptedRdfContentType = getAcceptedRdfContentType(request);
         //        if (acceptedRdfContentType.isPresent()) {
         //            return super.streamRdf(
@@ -148,7 +149,7 @@ public class PrecomputedUniProtKBController extends BasicSearchController<UniPro
         //        } else {}
 
         return super.stream(
-                () -> precomputedUniProtKBEntryService.stream(streamRequest),
+                () -> precomputedUniProtKBEntryService.streamByProteomeId(streamRequest),
                 streamRequest,
                 contentType,
                 request);

--- a/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBController.java
+++ b/uniprotkb-rest/src/main/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBController.java
@@ -39,7 +39,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 @RequestMapping(value = PRECOMPUTED_ANNOTATION_RESOURCE)
 @Validated
 public class PrecomputedUniProtKBController extends BasicSearchController<UniProtKBEntry> {
-    private static final String DATA_TYPE = "uniprotkb";
     static final String PRECOMPUTED_ANNOTATION_RESOURCE = UNIPROTKB_RESOURCE + "/precomputed";
 
     private final PrecomputedUniProtKBEntryService precomputedUniProtKBEntryService;
@@ -134,20 +133,6 @@ public class PrecomputedUniProtKBController extends BasicSearchController<UniPro
         streamRequest.setUpId(upId);
         MediaType contentType = getAcceptHeader(request);
         setBasicRequestFormat(streamRequest, request);
-
-        // TODO cleanup later
-        //        Optional<String> acceptedRdfContentType = getAcceptedRdfContentType(request);
-        //        if (acceptedRdfContentType.isPresent()) {
-        //            return super.streamRdf(
-        //                    () ->
-        //                            precomputedUniProtKBEntryService.streamRdf(
-        //                                    streamRequest, DATA_TYPE,
-        // acceptedRdfContentType.get()),
-        //                    streamRequest,
-        //                    contentType,
-        //                    request);
-        //        } else {}
-
         return super.stream(
                 () -> precomputedUniProtKBEntryService.streamByProteomeId(streamRequest),
                 streamRequest,

--- a/uniprotkb-rest/src/main/resources/application.properties
+++ b/uniprotkb-rest/src/main/resources/application.properties
@@ -95,6 +95,18 @@ voldemort.precomputed.annotation.numberOfConnections=10
 voldemort.precomputed.annotation.storeName=precomputed-annotation
 voldemort.precomputed.annotation.brotliEnabled=true
 
+#TODO tune these?
+############################### PrecomputedAnnotation Entry Store (Voldemort) Streaming properties ###############################
+streamer.precomputedannotation.storeBatchSize=5000
+streamer.precomputedannotation.storeFetchMaxRetries=5
+streamer.precomputedannotation.storeFetchRetryDelayMillis=500
+streamer.precomputedannotation.zkHost=wp-np3-db:5191,wp-np3-d0:5191,wp-np3-d1:5191
+# TODO check if id field name is correct
+streamer.precomputedannotation.idFieldName=accession
+streamer.precomputedannotation.requestHandler=/export
+streamer.precomputedannotation.collection=precomputedannotation
+streamer.precomputedannotation.storeMaxCountToRetrieve=5000000
+
 ############################### Entry Store (Voldemort) Streaming properties ###############################
 streamer.uniprot.storeBatchSize=5000
 streamer.uniprot.storeFetchMaxRetries=5

--- a/uniprotkb-rest/src/main/resources/application.properties
+++ b/uniprotkb-rest/src/main/resources/application.properties
@@ -95,13 +95,11 @@ voldemort.precomputed.annotation.numberOfConnections=10
 voldemort.precomputed.annotation.storeName=precomputed-annotation
 voldemort.precomputed.annotation.brotliEnabled=true
 
-#TODO tune these?
 ############################### PrecomputedAnnotation Entry Store (Voldemort) Streaming properties ###############################
 streamer.precomputedannotation.storeBatchSize=5000
 streamer.precomputedannotation.storeFetchMaxRetries=5
 streamer.precomputedannotation.storeFetchRetryDelayMillis=500
 streamer.precomputedannotation.zkHost=wp-np3-db:5191,wp-np3-d0:5191,wp-np3-d1:5191
-# TODO check if id field name is correct
 streamer.precomputedannotation.idFieldName=accession
 streamer.precomputedannotation.requestHandler=/export
 streamer.precomputedannotation.collection=precomputedannotation
@@ -153,3 +151,7 @@ server.tomcat.max-connections=1000
 unisave.rest.endpoint=rest.uniprot.org/unisave/
 
 max.solr.or.clause.count=50
+
+#logging.level.root=DEBUG
+logging.level.org.springdoc=TRACE
+logging.level.org.springframework.web.servlet.mvc.method.annotation=TRACE

--- a/uniprotkb-rest/src/main/resources/application.properties
+++ b/uniprotkb-rest/src/main/resources/application.properties
@@ -151,7 +151,3 @@ server.tomcat.max-connections=1000
 unisave.rest.endpoint=rest.uniprot.org/unisave/
 
 max.solr.or.clause.count=50
-
-#logging.level.root=DEBUG
-logging.level.org.springdoc=TRACE
-logging.level.org.springframework.web.servlet.mvc.method.annotation=TRACE

--- a/uniprotkb-rest/src/main/resources/swagger.properties
+++ b/uniprotkb-rest/src/main/resources/swagger.properties
@@ -1,3 +1,0 @@
-#springfox.documentation.swagger.v2.path=/api.json
-springfox.documentation.swagger.v2.path=/swagger.json
-BasePath=/uniprot/api

--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBControllerIT.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBControllerIT.java
@@ -55,6 +55,7 @@ import org.uniprot.store.datastore.voldemort.uniprot.VoldemortInMemoryUniprotEnt
 import org.uniprot.store.indexer.DataStoreManager;
 import org.uniprot.store.search.document.precomputed.PrecomputedAnnotationDocument;
 
+// TODO
 @ContextConfiguration(classes = {UniProtKBREST.class})
 @ActiveProfiles(profiles = "offline")
 @AutoConfigureWebClient

--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBControllerIT.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBControllerIT.java
@@ -55,7 +55,6 @@ import org.uniprot.store.datastore.voldemort.uniprot.VoldemortInMemoryUniprotEnt
 import org.uniprot.store.indexer.DataStoreManager;
 import org.uniprot.store.search.document.precomputed.PrecomputedAnnotationDocument;
 
-// TODO
 @ContextConfiguration(classes = {UniProtKBREST.class})
 @ActiveProfiles(profiles = "offline")
 @AutoConfigureWebClient

--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBStreamControllerIT.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBStreamControllerIT.java
@@ -1,0 +1,234 @@
+package org.uniprot.api.uniprotkb.controller;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocumentList;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.uniprot.api.common.repository.solrstream.FacetTupleStreamTemplate;
+import org.uniprot.api.common.repository.stream.common.TupleStreamTemplate;
+import org.uniprot.api.common.repository.stream.store.uniprotkb.TaxonomyLineageRepository;
+import org.uniprot.api.rest.controller.AbstractStreamControllerIT;
+import org.uniprot.api.rest.controller.ControllerITUtils;
+import org.uniprot.api.rest.output.header.HttpCommonHeaderConfig;
+import org.uniprot.api.rest.validation.error.ErrorHandlerConfig;
+import org.uniprot.api.uniprotkb.UniProtKBREST;
+import org.uniprot.api.uniprotkb.common.repository.search.ProteomeTaxonomyRepository;
+import org.uniprot.api.uniprotkb.common.repository.store.precomputed.PrecomputedAnnotationStoreClient;
+import org.uniprot.core.proteome.ProteomeEntry;
+import org.uniprot.core.proteome.ProteomeType;
+import org.uniprot.core.proteome.impl.ProteomeEntryBuilder;
+import org.uniprot.core.taxonomy.impl.TaxonomyLineageBuilder;
+import org.uniprot.core.uniprotkb.UniProtKBEntry;
+import org.uniprot.core.uniprotkb.impl.UniProtKBEntryBuilder;
+import org.uniprot.core.uniprotkb.taxonomy.Taxonomy;
+import org.uniprot.core.uniprotkb.taxonomy.impl.TaxonomyBuilder;
+import org.uniprot.store.indexer.uniprot.mockers.UniProtEntryMocker;
+import org.uniprot.store.search.SolrCollection;
+import org.uniprot.store.search.document.precomputed.PrecomputedAnnotationDocument;
+import org.uniprot.store.search.document.proteome.ProteomeDocument;
+import org.uniprot.store.spark.indexer.precomputed.mapper.PrecomputedAnnotationEntryToDocumentMapper;
+import org.uniprot.store.spark.indexer.proteome.mapper.ProteomeEntryToProteomeDocumentMapper;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ActiveProfiles(profiles = "offline")
+@ContextConfiguration(classes = {UniProtKBREST.class, ErrorHandlerConfig.class})
+@AutoConfigureWebClient
+@WebMvcTest(PrecomputedUniProtKBController.class)
+@ExtendWith(value = {SpringExtension.class, MockitoExtension.class})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class PrecomputedUniProtKBStreamControllerIT extends AbstractStreamControllerIT {
+    private static final String streamRequestPath = "/uniprotkb/precomputed/proteome/{upId}/stream";
+
+    private static final UniProtKBEntry TEMPLATE_ENTRY =
+            UniProtEntryMocker.create(UniProtEntryMocker.Type.SP_CANONICAL);
+
+    private final PrecomputedAnnotationEntryToDocumentMapper
+            precomputedAnnotationEntryToDocumentMapper =
+                    new PrecomputedAnnotationEntryToDocumentMapper();
+    private final ProteomeEntryToProteomeDocumentMapper proteomeEntryToProteomeDocumentMapper =
+            new ProteomeEntryToProteomeDocumentMapper();
+
+    @Autowired private PrecomputedAnnotationStoreClient precomputedAnnotationStoreClient;
+
+    @Autowired
+    @Qualifier("uniProtKBSolrClient")
+    private SolrClient solrClient;
+
+    @Qualifier("precomputedAnnotationTupleStream")
+    @Autowired
+    private TupleStreamTemplate tupleStreamTemplate;
+
+    @Autowired private FacetTupleStreamTemplate facetTupleStreamTemplate;
+
+    @Autowired private TaxonomyLineageRepository taxRepository;
+    @Autowired private ProteomeTaxonomyRepository proteomeTaxonomyRepository;
+
+    @Autowired private MockMvc mockMvc;
+
+    @Override
+    protected List<SolrCollection> getSolrCollections() {
+        return List.of(SolrCollection.precomputedannotation, SolrCollection.proteome);
+    }
+
+    @Override
+    protected TupleStreamTemplate getTupleStreamTemplate() {
+        return tupleStreamTemplate;
+    }
+
+    @Override
+    protected FacetTupleStreamTemplate getFacetTupleStreamTemplate() {
+        return facetTupleStreamTemplate;
+    }
+
+    /**
+     * For the following tests, ensure the number of hits for each query is less than the maximum
+     * number allowed to be streamed (configured in {@link
+     * org.uniprot.api.common.repository.stream.store.StreamerConfigProperties})
+     */
+    @BeforeAll
+    void saveEntriesInSolrAndStore() throws Exception {
+        saveEntries();
+        long queryHits = 100L;
+        QueryResponse response = mock(QueryResponse.class);
+        SolrDocumentList results = mock(SolrDocumentList.class);
+        when(results.getNumFound()).thenReturn(queryHits);
+        when(response.getResults()).thenReturn(results);
+        when(solrClient.query(anyString(), any())).thenReturn(response);
+
+        ReflectionTestUtils.setField(taxRepository, "solrClient", cloudSolrClient);
+        ReflectionTestUtils.setField(proteomeTaxonomyRepository, "solrClient", cloudSolrClient);
+    }
+
+    @Test
+    void streamCanReturnSuccess() throws Exception {
+        // when
+        MockHttpServletRequestBuilder requestBuilder =
+                MockMvcRequestBuilders.get(streamRequestPath, "UP000000002")
+                        .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
+                        .param("query", "content:*");
+
+        MvcResult response = mockMvc.perform(requestBuilder).andReturn();
+
+        // then
+        mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(response))
+                .andDo(MockMvcResultHandlers.log())
+                .andExpect(MockMvcResultMatchers.status().is(HttpStatus.OK.value()))
+                .andExpect(MockMvcResultMatchers.header().doesNotExist("Content-Disposition"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.results.size()", is(10)))
+                .andExpect(
+                        MockMvcResultMatchers.jsonPath(
+                                "$.results.*.primaryAccession",
+                                containsInAnyOrder(
+                                        "UP000000001-992", "UP000000002-992", "UP000000003-992", "UP000000004-992",
+                                        "UP000000005-992", "UP000000006-992", "UP000000007-992", "UP000000008-992",
+                                        "UP000000009-992", "UP000000010-992")))
+                .andExpect(
+                        MockMvcResultMatchers.header()
+                                .string(HttpHeaders.CACHE_CONTROL, ControllerITUtils.CACHE_VALUE))
+                .andExpect(
+                        MockMvcResultMatchers.header()
+                                .stringValues(
+                                        HttpHeaders.VARY,
+                                        HttpHeaders.ACCEPT,
+                                        HttpHeaders.ACCEPT_ENCODING,
+                                        HttpCommonHeaderConfig.X_UNIPROT_RELEASE,
+                                        HttpCommonHeaderConfig.X_API_DEPLOYMENT_DATE));
+    }
+
+    @Test
+    void streamDownloadCompressedFile() throws Exception {
+        // when
+        MockHttpServletRequestBuilder requestBuilder =
+                MockMvcRequestBuilders.get(streamRequestPath, "UP000000002")
+                        .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
+                        .param("download", "true");
+
+        MvcResult response = mockMvc.perform(requestBuilder).andReturn();
+
+        // then
+        mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(response))
+                .andDo(MockMvcResultHandlers.log())
+                .andExpect(MockMvcResultMatchers.status().is(HttpStatus.OK.value()))
+                .andExpect(
+                        MockMvcResultMatchers.header()
+                                .string(
+                                        "Content-Disposition",
+                                        startsWith(
+                                                "form-data; name=\"attachment\"; filename=\"uniprotkb_")))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.results.size()", is(10)));
+    }
+
+    private void saveEntries() throws Exception {
+        for (int i = 1; i <= 10; i++) {
+            savePrecomputedAnnotationEntry(i, 992);
+        }
+        cloudSolrClient.commit(SolrCollection.precomputedannotation.name());
+        saveProteomeEntry("UP000000002", 992, 991, 993);
+        cloudSolrClient.commit(SolrCollection.proteome.name());
+    }
+
+    private void saveProteomeEntry(String upId, long taxId, long... taxLinageId) throws Exception {
+        Taxonomy taxonomy = new TaxonomyBuilder().taxonId(taxId).build();
+
+        ProteomeEntryBuilder builder =
+                new ProteomeEntryBuilder()
+                        .proteomeId(upId)
+                        .taxonomy(taxonomy)
+                        .proteomeType(ProteomeType.REFERENCE)
+                        .annotationScore(15);
+
+        for (long id : taxLinageId) {
+            builder.taxonLineagesAdd(new TaxonomyLineageBuilder().taxonId(id).build());
+        }
+        builder.taxonLineagesAdd(new TaxonomyLineageBuilder().taxonId(taxId).build());
+        ProteomeEntry proteomeEntry = builder.build();
+        ProteomeDocument proteomeDocument =
+                proteomeEntryToProteomeDocumentMapper.call(proteomeEntry);
+        cloudSolrClient.addBean(SolrCollection.proteome.name(), proteomeDocument);
+    }
+
+    private void savePrecomputedAnnotationEntry(int upId, int taxId) throws Exception {
+        UniProtKBEntryBuilder uniProtKBEntryBuilder = UniProtKBEntryBuilder.from(TEMPLATE_ENTRY);
+        String acc = String.format("UP%09d-%d", upId, taxId);
+        uniProtKBEntryBuilder.primaryAccession(acc);
+
+        UniProtKBEntry uniProtKBEntry = uniProtKBEntryBuilder.build();
+        PrecomputedAnnotationDocument precomputedAnnotationDocument =
+                precomputedAnnotationEntryToDocumentMapper.call(uniProtKBEntry);
+
+        cloudSolrClient.addBean(
+                SolrCollection.precomputedannotation.name(), precomputedAnnotationDocument);
+        precomputedAnnotationStoreClient.saveEntry(uniProtKBEntry);
+    }
+}

--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBStreamControllerIT.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBStreamControllerIT.java
@@ -1,12 +1,15 @@
 package org.uniprot.api.uniprotkb.controller;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.uniprot.api.rest.output.UniProtMediaType.*;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.response.QueryResponse;
@@ -15,6 +18,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -131,12 +136,11 @@ public class PrecomputedUniProtKBStreamControllerIT extends AbstractStreamContro
     }
 
     @Test
-    void streamCanReturnSuccess() throws Exception {
+    void streamByProteomeIdCanReturnSuccess() throws Exception {
         // when
         MockHttpServletRequestBuilder requestBuilder =
                 MockMvcRequestBuilders.get(streamRequestPath, "UP000000002")
-                        .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
-                        .param("query", "content:*");
+                        .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
 
         MvcResult response = mockMvc.perform(requestBuilder).andReturn();
 
@@ -160,6 +164,10 @@ public class PrecomputedUniProtKBStreamControllerIT extends AbstractStreamContro
                                         "UP000000008-992",
                                         "UP000000009-992",
                                         "UP000000010-992")))
+                // To test that the whole entry is present in the response
+                .andExpect(
+                        MockMvcResultMatchers.jsonPath(
+                                "$.results.*.annotationScore", everyItem(is(0.0))))
                 .andExpect(
                         MockMvcResultMatchers.header()
                                 .string(HttpHeaders.CACHE_CONTROL, ControllerITUtils.CACHE_VALUE))
@@ -174,7 +182,43 @@ public class PrecomputedUniProtKBStreamControllerIT extends AbstractStreamContro
     }
 
     @Test
-    void streamDownloadCompressedFile() throws Exception {
+    void streamByProteomeIdCanReturnSuccessForListContentType() throws Exception {
+        // when
+        MockHttpServletRequestBuilder requestBuilder =
+                MockMvcRequestBuilders.get(streamRequestPath, "UP000000002")
+                        .header(HttpHeaders.ACCEPT, LIST_MEDIA_TYPE_VALUE);
+
+        MvcResult response = mockMvc.perform(requestBuilder).andReturn();
+
+        String content =
+                mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(response))
+                        .andExpect(MockMvcResultMatchers.status().isOk())
+                        .andExpect(
+                                MockMvcResultMatchers.header().doesNotExist("Content-Disposition"))
+                        .andExpect(
+                                MockMvcResultMatchers.header()
+                                        .string(
+                                                HttpHeaders.CACHE_CONTROL,
+                                                ControllerITUtils.CACHE_VALUE))
+                        .andExpect(
+                                MockMvcResultMatchers.header()
+                                        .stringValues(
+                                                HttpHeaders.VARY,
+                                                HttpHeaders.ACCEPT,
+                                                HttpHeaders.ACCEPT_ENCODING,
+                                                HttpCommonHeaderConfig.X_UNIPROT_RELEASE,
+                                                HttpCommonHeaderConfig.X_API_DEPLOYMENT_DATE))
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        IntStream.rangeClosed(1, 10)
+                .mapToObj(i -> String.format("UP%09d-992", i))
+                .forEach(id -> assertThat(content, containsString(id)));
+    }
+
+    @Test
+    void streamByProteomeIdDownloadCompressedFile() throws Exception {
         // when
         MockHttpServletRequestBuilder requestBuilder =
                 MockMvcRequestBuilders.get(streamRequestPath, "UP000000002")
@@ -194,6 +238,38 @@ public class PrecomputedUniProtKBStreamControllerIT extends AbstractStreamContro
                                         startsWith(
                                                 "form-data; name=\"attachment\"; filename=\"uniprotkb_")))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.results.size()", is(10)));
+    }
+
+    @Test
+    void streamByProteomeIdTaxonomyNotFound() throws Exception {
+        // when
+        MockHttpServletRequestBuilder requestBuilder =
+                MockMvcRequestBuilders.get(streamRequestPath, "UP000000111")
+                        .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
+
+        MvcResult response = mockMvc.perform(requestBuilder).andReturn();
+
+        // then
+        mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(response))
+                .andDo(MockMvcResultHandlers.log())
+                .andExpect(MockMvcResultMatchers.status().is(HttpStatus.NOT_FOUND.value()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                MediaType.APPLICATION_XML_VALUE,
+                TSV_MEDIA_TYPE_VALUE,
+                FF_MEDIA_TYPE_VALUE,
+                XLS_MEDIA_TYPE_VALUE,
+                FASTA_MEDIA_TYPE_VALUE,
+                GFF_MEDIA_TYPE_VALUE
+            })
+    void streamByProteomeIdUnsupportedAcceptContentTypes(String mediaType) throws Exception {
+        mockMvc.perform(
+                        MockMvcRequestBuilders.get(streamRequestPath, "UP000000002")
+                                .header(HttpHeaders.ACCEPT, mediaType))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest());
     }
 
     private void saveEntries() throws Exception {

--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBStreamControllerIT.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBStreamControllerIT.java
@@ -153,7 +153,7 @@ public class PrecomputedUniProtKBStreamControllerIT extends AbstractStreamContro
                 .andExpect(
                         MockMvcResultMatchers.jsonPath(
                                 "$.results.*.primaryAccession",
-                                containsInAnyOrder(
+                                contains(
                                         "UP000000001-992",
                                         "UP000000002-992",
                                         "UP000000003-992",
@@ -179,6 +179,38 @@ public class PrecomputedUniProtKBStreamControllerIT extends AbstractStreamContro
                                         HttpHeaders.ACCEPT_ENCODING,
                                         HttpCommonHeaderConfig.X_UNIPROT_RELEASE,
                                         HttpCommonHeaderConfig.X_API_DEPLOYMENT_DATE));
+    }
+
+    @Test
+    void streamByProteomeIdCanReturnSuccessWithSortAccessionDesc() throws Exception {
+        // when
+        MockHttpServletRequestBuilder requestBuilder =
+                MockMvcRequestBuilders.get(streamRequestPath, "UP000000002")
+                        .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
+                        .queryParam("sort", "accession desc");
+
+        MvcResult response = mockMvc.perform(requestBuilder).andReturn();
+
+        // then
+        mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(response))
+                .andDo(MockMvcResultHandlers.log())
+                .andExpect(MockMvcResultMatchers.status().is(HttpStatus.OK.value()))
+                .andExpect(MockMvcResultMatchers.header().doesNotExist("Content-Disposition"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.results.size()", is(10)))
+                .andExpect(
+                        MockMvcResultMatchers.jsonPath(
+                                "$.results.*.primaryAccession",
+                                contains(
+                                        "UP000000010-992",
+                                        "UP000000009-992",
+                                        "UP000000008-992",
+                                        "UP000000007-992",
+                                        "UP000000006-992",
+                                        "UP000000005-992",
+                                        "UP000000004-992",
+                                        "UP000000003-992",
+                                        "UP000000002-992",
+                                        "UP000000001-992")));
     }
 
     @Test

--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBStreamControllerIT.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/PrecomputedUniProtKBStreamControllerIT.java
@@ -150,9 +150,16 @@ public class PrecomputedUniProtKBStreamControllerIT extends AbstractStreamContro
                         MockMvcResultMatchers.jsonPath(
                                 "$.results.*.primaryAccession",
                                 containsInAnyOrder(
-                                        "UP000000001-992", "UP000000002-992", "UP000000003-992", "UP000000004-992",
-                                        "UP000000005-992", "UP000000006-992", "UP000000007-992", "UP000000008-992",
-                                        "UP000000009-992", "UP000000010-992")))
+                                        "UP000000001-992",
+                                        "UP000000002-992",
+                                        "UP000000003-992",
+                                        "UP000000004-992",
+                                        "UP000000005-992",
+                                        "UP000000006-992",
+                                        "UP000000007-992",
+                                        "UP000000008-992",
+                                        "UP000000009-992",
+                                        "UP000000010-992")))
                 .andExpect(
                         MockMvcResultMatchers.header()
                                 .string(HttpHeaders.CACHE_CONTROL, ControllerITUtils.CACHE_VALUE))

--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBGetByAccessionsIT.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBGetByAccessionsIT.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpHeaders;
@@ -107,7 +108,10 @@ class UniProtKBGetByAccessionsIT extends AbstractGetByIdsControllerIT {
     @Autowired private UniProtStoreClient<UniProtKBEntry> uniProtKBStoreClient;
 
     @Autowired private FacetTupleStreamTemplate facetTupleStreamTemplate;
-    @Autowired private TupleStreamTemplate tupleStreamTemplate;
+
+    @Qualifier("uniProtKBTupleStream")
+    @Autowired
+    private TupleStreamTemplate tupleStreamTemplate;
 
     @Autowired private MockMvc mockMvc;
 

--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBGetByAccessionsPostIT.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBGetByAccessionsPostIT.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -71,7 +72,10 @@ class UniProtKBGetByAccessionsPostIT extends AbstractGetByIdsPostControllerIT {
     @Autowired private UniProtStoreClient<UniProtKBEntry> uniProtKBStoreClient;
 
     @Autowired private FacetTupleStreamTemplate facetTupleStreamTemplate;
-    @Autowired private TupleStreamTemplate tupleStreamTemplate;
+
+    @Qualifier("uniProtKBTupleStream")
+    @Autowired
+    private TupleStreamTemplate tupleStreamTemplate;
 
     @Autowired private MockMvc mockMvc;
 

--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBGetByAccessionsWithFilterIT.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBGetByAccessionsWithFilterIT.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpHeaders;
@@ -75,7 +76,9 @@ class UniProtKBGetByAccessionsWithFilterIT extends AbstractStreamControllerIT {
 
     @Autowired private FacetTupleStreamTemplate facetTupleStreamTemplate;
 
-    @Autowired private TupleStreamTemplate tupleStreamTemplate;
+    @Qualifier("uniProtKBTupleStream")
+    @Autowired
+    private TupleStreamTemplate tupleStreamTemplate;
 
     @BeforeAll
     void saveEntriesInSolrAndStore() throws Exception {

--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBStreamControllerIT.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBStreamControllerIT.java
@@ -113,6 +113,7 @@ class UniProtKBStreamControllerIT extends AbstractStreamControllerIT {
     private SolrClient solrClient;
 
     @Autowired private FacetTupleStreamTemplate facetTupleStreamTemplate;
+    @Qualifier("uniProtKBTupleStream")
     @Autowired private TupleStreamTemplate tupleStreamTemplate;
     @Autowired private TaxonomyLineageRepository taxRepository;
 

--- a/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBStreamControllerIT.java
+++ b/uniprotkb-rest/src/test/java/org/uniprot/api/uniprotkb/controller/UniProtKBStreamControllerIT.java
@@ -113,8 +113,11 @@ class UniProtKBStreamControllerIT extends AbstractStreamControllerIT {
     private SolrClient solrClient;
 
     @Autowired private FacetTupleStreamTemplate facetTupleStreamTemplate;
+
     @Qualifier("uniProtKBTupleStream")
-    @Autowired private TupleStreamTemplate tupleStreamTemplate;
+    @Autowired
+    private TupleStreamTemplate tupleStreamTemplate;
+
     @Autowired private TaxonomyLineageRepository taxRepository;
 
     @BeforeAll

--- a/uniprotkb-rest/src/test/resources/application.properties
+++ b/uniprotkb-rest/src/test/resources/application.properties
@@ -39,6 +39,16 @@ spring.mvc.async.request-timeout=-1
 #voldemort.uniprot.numberOfConnections=20
 #voldemort.uniprot.storeName=avro-uniprot
 
+############################### PrecomputedAnnotation Entry Store (Voldemort) Streaming properties ###############################
+streamer.precomputedannotation.storeBatchSize=5000
+streamer.precomputedannotation.storeFetchMaxRetries=5
+streamer.precomputedannotation.storeFetchRetryDelayMillis=500
+streamer.precomputedannotation.zkHost=localhost
+streamer.precomputedannotation.idFieldName=accession
+streamer.precomputedannotation.requestHandler=/export
+streamer.precomputedannotation.collection=precomputedannotation
+streamer.precomputedannotation.storeMaxCountToRetrieve=15
+
 ############################### Entry Store (Voldemort) Streaming properties ###############################
 streamer.uniprot.searchBatchSize=5
 streamer.uniprot.storeBatchSize=10


### PR DESCRIPTION
This PR is to to add JSON based stream endpoint for precomputed annotations by proteome id.

- Note that this PR depends on the schema change at https://github.com/ebi-uniprot/uniprot-store/pull/448
- PR for the config property changes were added at https://gitlab.ebi.ac.uk/uniprot/deployment/unp.ci.api.k8s/-/merge_requests/131