### PR TITLE
Add UniProtKB Solr 9 shadow query logging

### DIFF
--- a/common-rest/src/main/java/org/uniprot/api/common/repository/search/SolrQueryRepository.java
+++ b/common-rest/src/main/java/org/uniprot/api/common/repository/search/SolrQueryRepository.java
@@ -68,6 +68,7 @@ public abstract class SolrQueryRepository<T extends Document> {
             QueryResponse solrResponse = search(request, page.getCursor());
 
             List<T> resultList = getResponseDocuments(solrResponse);
+            logSearchResponse(request, cursor, solrResponse, resultList);
             page.setNextCursor(solrResponse.getNextCursorMark());
             page.setTotalElements(solrResponse.getResults().getNumFound());
 
@@ -144,6 +145,12 @@ public abstract class SolrQueryRepository<T extends Document> {
         return solrResponse.getBeans(tClass);
     }
 
+    protected void logSearchResponse(
+            SolrRequest request, String cursor, QueryResponse solrResponse, List<T> documents) {}
+
+    protected void logConvertedSolrRequest(
+            SolrRequest request, String cursor, JsonQueryRequest solrQuery) {}
+
     private QueryResponse search(SolrRequest request, String cursor)
             throws IOException, SolrServerException {
         JsonQueryRequest solrQuery = requestConverter.toJsonQueryRequest(request);
@@ -155,6 +162,7 @@ public abstract class SolrQueryRepository<T extends Document> {
                     .set(CursorMarkParams.CURSOR_MARK_PARAM, CursorMarkParams.CURSOR_MARK_START)
                     .set(SPELLCHECK_PARAM, true);
         }
+        logConvertedSolrRequest(request, cursor, solrQuery);
         return solrQuery.process(solrClient, collection.toString());
     }
 

--- a/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/repository/search/UniprotQueryRepository.java
+++ b/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/repository/search/UniprotQueryRepository.java
@@ -1,12 +1,31 @@
 package org.uniprot.api.uniprotkb.common.repository.search;
 
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.request.json.JsonQueryRequest;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.params.CursorMarkParams;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Repository;
+import org.uniprot.api.common.repository.search.QueryResult;
 import org.uniprot.api.common.repository.search.SolrQueryRepository;
+import org.uniprot.api.common.repository.search.SolrRequest;
 import org.uniprot.api.common.repository.search.SolrRequestConverter;
 import org.uniprot.api.rest.respository.facet.impl.UniProtKBFacetConfig;
 import org.uniprot.store.search.SolrCollection;
+import org.uniprot.store.search.document.Document;
 import org.uniprot.store.search.document.uniprot.UniProtDocument;
 
 /**
@@ -16,8 +35,35 @@ import org.uniprot.store.search.document.uniprot.UniProtDocument;
  */
 @Repository
 public class UniprotQueryRepository extends SolrQueryRepository<UniProtDocument> {
+    private static final Logger SHADOW_LOGGER = LoggerFactory.getLogger("solr9-shadow");
+    private static final int IDS_TO_LOG = 25;
+    private static final AtomicInteger THREAD_COUNTER = new AtomicInteger();
+    private static final AtomicLong SHADOW_ID_COUNTER = new AtomicLong();
+    private static final ThreadLocal<Long> CURRENT_SHADOW_ID = new ThreadLocal<>();
+    private static final ThreadLocal<String> CURRENT_SOLR_PARAMS = new ThreadLocal<>();
+    private static final ExecutorService SHADOW_EXECUTOR =
+            new ThreadPoolExecutor(
+                    1,
+                    2,
+                    30L,
+                    TimeUnit.SECONDS,
+                    new ArrayBlockingQueue<>(100),
+                    runnable -> {
+                        Thread thread =
+                                new Thread(
+                                        runnable,
+                                        "solr9-shadow-" + THREAD_COUNTER.incrementAndGet());
+                        thread.setDaemon(true);
+                        return thread;
+                    },
+                    new ThreadPoolExecutor.AbortPolicy());
+
+    private final SolrClient solr9Client;
+    private final SolrRequestConverter requestConverter;
+
     public UniprotQueryRepository(
             @Qualifier("uniProtKBSolrClient") SolrClient solrClient,
+            @Qualifier("uniProtKBSolr9Client") ObjectProvider<SolrClient> solr9Client,
             UniProtKBFacetConfig facetConfig,
             SolrRequestConverter requestConverter) {
         super(
@@ -26,5 +72,117 @@ public class UniprotQueryRepository extends SolrQueryRepository<UniProtDocument>
                 UniProtDocument.class,
                 facetConfig,
                 requestConverter);
+        this.solr9Client = solr9Client.getIfAvailable();
+        this.requestConverter = requestConverter;
+    }
+
+    @Override
+    public QueryResult<UniProtDocument> searchPage(SolrRequest request, String cursor) {
+        long shadowId = SHADOW_ID_COUNTER.incrementAndGet();
+        try {
+            CURRENT_SHADOW_ID.set(shadowId);
+            QueryResult<UniProtDocument> result = super.searchPage(request, cursor);
+            shadowSearchPage(shadowId, request, cursor);
+            return result;
+        } finally {
+            CURRENT_SHADOW_ID.remove();
+            CURRENT_SOLR_PARAMS.remove();
+        }
+    }
+
+    @Override
+    protected void logConvertedSolrRequest(
+            SolrRequest request, String cursor, JsonQueryRequest solrQuery) {
+        CURRENT_SOLR_PARAMS.set(String.valueOf(solrQuery.getParams()));
+    }
+
+    @Override
+    protected void logSearchResponse(
+            SolrRequest request,
+            String cursor,
+            QueryResponse solrResponse,
+            List<UniProtDocument> documents) {
+        Long shadowId = CURRENT_SHADOW_ID.get();
+        if (shadowId != null) {
+            SHADOW_LOGGER.info(
+                    "shadowId={} solr=8 collection=uniprot numFound={} qTime={} cursor={} ids={} params={} query={} filters={} sorts={} rows={} facets={}",
+                    shadowId,
+                    solrResponse.getResults().getNumFound(),
+                    solrResponse.getQTime(),
+                    cursor,
+                    getDocumentIds(documents),
+                    CURRENT_SOLR_PARAMS.get(),
+                    request.getQuery(),
+                    request.getFilterQueries(),
+                    request.getSorts(),
+                    request.getRows(),
+                    request.getFacets());
+        }
+    }
+
+    private void shadowSearchPage(long shadowId, SolrRequest request, String cursor) {
+        if (solr9Client == null) {
+            return;
+        }
+        try {
+            SHADOW_EXECUTOR.execute(
+                    () -> {
+                        try {
+                            JsonQueryRequest solrQuery =
+                                    requestConverter.toJsonQueryRequest(request);
+                            ModifiableSolrParams params =
+                                    (ModifiableSolrParams) solrQuery.getParams();
+                            if (cursor != null && !cursor.isEmpty()) {
+                                params.set(CursorMarkParams.CURSOR_MARK_PARAM, cursor);
+                            } else {
+                                params.set(
+                                                CursorMarkParams.CURSOR_MARK_PARAM,
+                                                CursorMarkParams.CURSOR_MARK_START)
+                                        .set(SPELLCHECK_PARAM, true);
+                            }
+                            QueryResponse response =
+                                    solrQuery.process(
+                                            solr9Client, SolrCollection.uniprot.toString());
+                            SHADOW_LOGGER.info(
+                                    "shadowId={} solr=9 collection=uniprot numFound={} qTime={} cursor={} ids={} params={} query={} filters={} sorts={} rows={} facets={}",
+                                    shadowId,
+                                    response.getResults().getNumFound(),
+                                    response.getQTime(),
+                                    cursor,
+                                    getDocumentIds(response.getBeans(UniProtDocument.class)),
+                                    solrQuery.getParams(),
+                                    request.getQuery(),
+                                    request.getFilterQueries(),
+                                    request.getSorts(),
+                                    request.getRows(),
+                                    request.getFacets());
+                        } catch (Exception e) {
+                            SHADOW_LOGGER.warn(
+                                    "shadowId={} solr=9 collection=uniprot failed cursor={} query={} filters={} sorts={} rows={} facets={}",
+                                    shadowId,
+                                    cursor,
+                                    request.getQuery(),
+                                    request.getFilterQueries(),
+                                    request.getSorts(),
+                                    request.getRows(),
+                                    request.getFacets(),
+                                    e);
+                        }
+                    });
+        } catch (RejectedExecutionException e) {
+            SHADOW_LOGGER.warn(
+                    "shadowId={} solr=9 collection=uniprot skipped=true reason=queue_full cursor={} query={} filters={} sorts={} rows={} facets={}",
+                    shadowId,
+                    cursor,
+                    request.getQuery(),
+                    request.getFilterQueries(),
+                    request.getSorts(),
+                    request.getRows(),
+                    request.getFacets());
+        }
+    }
+
+    private List<String> getDocumentIds(List<? extends Document> documents) {
+        return documents.stream().limit(IDS_TO_LOG).map(Document::getDocumentId).toList();
     }
 }

--- a/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/repository/search/UniprotQueryRepository.java
+++ b/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/repository/search/UniprotQueryRepository.java
@@ -23,6 +23,7 @@ import org.uniprot.api.common.repository.search.QueryResult;
 import org.uniprot.api.common.repository.search.SolrQueryRepository;
 import org.uniprot.api.common.repository.search.SolrRequest;
 import org.uniprot.api.common.repository.search.SolrRequestConverter;
+import org.uniprot.api.common.repository.search.page.impl.CursorPage;
 import org.uniprot.api.rest.respository.facet.impl.UniProtKBFacetConfig;
 import org.uniprot.store.search.SolrCollection;
 import org.uniprot.store.search.document.Document;
@@ -82,7 +83,11 @@ public class UniprotQueryRepository extends SolrQueryRepository<UniProtDocument>
         try {
             CURRENT_SHADOW_ID.set(shadowId);
             QueryResult<UniProtDocument> result = super.searchPage(request, cursor);
-            shadowSearchPage(shadowId, request, cursor);
+            shadowSearchPage(
+                    shadowId,
+                    request,
+                    cursor,
+                    CursorPage.of(cursor, request.getRows()).getCursor());
             return result;
         } finally {
             CURRENT_SHADOW_ID.remove();
@@ -120,7 +125,8 @@ public class UniprotQueryRepository extends SolrQueryRepository<UniProtDocument>
         }
     }
 
-    private void shadowSearchPage(long shadowId, SolrRequest request, String cursor) {
+    private void shadowSearchPage(
+            long shadowId, SolrRequest request, String cursor, String solrCursor) {
         if (solr9Client == null) {
             return;
         }
@@ -132,8 +138,8 @@ public class UniprotQueryRepository extends SolrQueryRepository<UniProtDocument>
                                     requestConverter.toJsonQueryRequest(request);
                             ModifiableSolrParams params =
                                     (ModifiableSolrParams) solrQuery.getParams();
-                            if (cursor != null && !cursor.isEmpty()) {
-                                params.set(CursorMarkParams.CURSOR_MARK_PARAM, cursor);
+                            if (solrCursor != null && !solrCursor.isEmpty()) {
+                                params.set(CursorMarkParams.CURSOR_MARK_PARAM, solrCursor);
                             } else {
                                 params.set(
                                                 CursorMarkParams.CURSOR_MARK_PARAM,

--- a/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/repository/store/ResultsConfig.java
+++ b/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/repository/store/ResultsConfig.java
@@ -12,6 +12,7 @@ import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -46,13 +47,37 @@ public class ResultsConfig {
     @Bean("uniProtKBSolrClient")
     @Profile("live")
     public SolrClient uniProtKBSolrClient(
-            HttpClient httpClient, UniProtKBRepositoryConfigProperties config) {
+            HttpClient httpClient,
+            @Qualifier("uniProtKBRepositoryConfigProperties")
+                    UniProtKBRepositoryConfigProperties config) {
         return buildSolrClient(
                 httpClient,
                 config.getZkHost(),
                 config.getConnectionTimeout(),
                 config.getSocketTimeout(),
                 config.getHttphost());
+    }
+
+    @Bean("uniProtKBSolr9Client")
+    @Profile("live")
+    @ConditionalOnExpression(
+            "'${spring.data.solr.kb.solr9.zkHost:}' != ''")
+    public SolrClient uniProtKBSolr9Client(
+            HttpClient httpClient,
+            @Qualifier("uniProtKBSolr9ConfigProperties")
+                    UniProtKBRepositoryConfigProperties config) {
+        return buildSolrClient(
+                httpClient,
+                config.getZkHost(),
+                config.getConnectionTimeout(),
+                config.getSocketTimeout(),
+                config.getHttphost());
+    }
+
+    @Bean("uniProtKBSolr9ConfigProperties")
+    @ConfigurationProperties(prefix = "spring.data.solr.kb.solr9")
+    public UniProtKBRepositoryConfigProperties uniProtKBSolr9ConfigProperties() {
+        return new UniProtKBRepositoryConfigProperties();
     }
 
     @Bean("uniProtKBTupleStream")

--- a/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/repository/store/ResultsConfig.java
+++ b/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/repository/store/ResultsConfig.java
@@ -60,8 +60,7 @@ public class ResultsConfig {
 
     @Bean("uniProtKBSolr9Client")
     @Profile("live")
-    @ConditionalOnExpression(
-            "'${spring.data.solr.kb.solr9.zkHost:}' != ''")
+    @ConditionalOnExpression("'${spring.data.solr.kb.solr9.zkHost:}' != ''")
     public SolrClient uniProtKBSolr9Client(
             HttpClient httpClient,
             @Qualifier("uniProtKBSolr9ConfigProperties")

--- a/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/repository/store/UniProtStoreConfig.java
+++ b/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/repository/store/UniProtStoreConfig.java
@@ -3,8 +3,8 @@ package org.uniprot.api.uniprotkb.common.repository.store;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.uniprot.api.common.repository.solrstream.FacetTupleStreamTemplate;
-import org.uniprot.api.rest.respository.RepositoryConfigProperties;
 import org.uniprot.api.rest.respository.UniProtKBRepositoryConfigProperties;
 import org.uniprot.core.uniprotkb.UniProtKBEntry;
 import org.uniprot.store.datastore.voldemort.VoldemortClient;
@@ -38,7 +38,8 @@ public class UniProtStoreConfig {
 
     @Bean
     public FacetTupleStreamTemplate uniProtKBFacetTupleStreamTemplate(
-            UniProtKBRepositoryConfigProperties configProperties) {
+            @Qualifier("uniProtKBRepositoryConfigProperties")
+                    UniProtKBRepositoryConfigProperties configProperties) {
         return FacetTupleStreamTemplate.builder()
                 .collection(SolrCollection.uniprot.name())
                 .zookeeperHost(configProperties.getZkHost())

--- a/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/repository/store/UniProtStoreConfig.java
+++ b/uniprotkb-common/src/main/java/org/uniprot/api/uniprotkb/common/repository/store/UniProtStoreConfig.java
@@ -1,9 +1,9 @@
 package org.uniprot.api.uniprotkb.common.repository.store;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.uniprot.api.common.repository.solrstream.FacetTupleStreamTemplate;
 import org.uniprot.api.rest.respository.UniProtKBRepositoryConfigProperties;
 import org.uniprot.core.uniprotkb.UniProtKBEntry;

--- a/uniprotkb-rest/src/main/resources/application.properties
+++ b/uniprotkb-rest/src/main/resources/application.properties
@@ -56,6 +56,12 @@ spring.data.solr.kb.password=${SOLR_KB_PASSWORD:${SOLR_PASSWORD}}
 spring.data.solr.kb.connectionTimeout=20000
 spring.data.solr.kb.socketTimeout=3600000
 
+spring.data.solr.kb.solr9.zkHost=${SOLR9_KB_ZK_HOST:}
+spring.data.solr.kb.solr9.username=${SOLR9_KB_USERNAME:${SOLR_KB_USERNAME:${SOLR_USERNAME}}}
+spring.data.solr.kb.solr9.password=${SOLR9_KB_PASSWORD:${SOLR_KB_PASSWORD:${SOLR_PASSWORD}}}
+spring.data.solr.kb.solr9.connectionTimeout=20000
+spring.data.solr.kb.solr9.socketTimeout=3600000
+
 #spring.data.solr.httphost=http://wp-np2-51.ebi.ac.uk:8683/solr
 spring.data.solr.zkHost=wp-np3-db:5191,wp-np3-d0:5191,wp-np3-d1:5191
 #spring.data.solr.zkHost=wp-np2-b3:5191,wp-np2-b4:5191,wp-np2-b5:5191


### PR DESCRIPTION
Adds temporary Solr 9 shadow querying for the UniProtKB uniprot collection.

  The API still returns results from the existing Solr 8 path. After the Solr 8 query completes, the same converted Solr request is sent asynchronously to a separate Solr 9 cluster for comparison. 

 Comparison logs use the dedicated solr9-shadow logger and include shadowId, Solr version, numFound, qTime, cursor, first 25 document IDs, converted Solr params, query, filters, sorts, rows, and facets.