### PR TITLE
chore: TRM-34245 Upgrade Testcontainers to 2.x

### DIFF
--- a/async-download-rest/pom.xml
+++ b/async-download-rest/pom.xml
@@ -55,7 +55,6 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>testcontainers</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>
@@ -66,14 +65,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<version>${testcontainers.version}</version>
+			<artifactId>testcontainers-junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>rabbitmq</artifactId>
-			<version>${testcontainers.version}</version>
+			<artifactId>testcontainers-rabbitmq</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/async-download-rest/src/test/java/org/uniprot/api/async/download/messaging/producer/SolrProducerMessageServiceIT.java
+++ b/async-download-rest/src/test/java/org/uniprot/api/async/download/messaging/producer/SolrProducerMessageServiceIT.java
@@ -10,14 +10,13 @@ import org.junit.jupiter.api.TestInstance;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mockito;
+import org.opentest4j.AssertionFailedError;
 import org.springframework.amqp.core.Message;
 import org.uniprot.api.async.download.messaging.consumer.MessageConsumer;
 import org.uniprot.api.async.download.messaging.repository.DownloadJobRepository;
 import org.uniprot.api.async.download.model.job.DownloadJob;
 import org.uniprot.api.async.download.model.request.SolrStreamDownloadRequest;
 import org.uniprot.api.rest.download.queue.IllegalDownloadJobSubmissionException;
-
-import junit.framework.AssertionFailedError;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class SolrProducerMessageServiceIT<

--- a/async-download-rest/src/test/java/org/uniprot/api/async/download/messaging/producer/idmapping/IdMappingProducerMessageServiceIT.java
+++ b/async-download-rest/src/test/java/org/uniprot/api/async/download/messaging/producer/idmapping/IdMappingProducerMessageServiceIT.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mockito;
+import org.opentest4j.AssertionFailedError;
 import org.redisson.api.RedissonClient;
 import org.redisson.spring.cache.CacheConfig;
 import org.redisson.spring.cache.RedissonSpringCacheManager;
@@ -45,8 +46,6 @@ import org.uniprot.api.idmapping.common.service.IdMappingJobCacheService;
 import org.uniprot.api.idmapping.common.service.impl.RedisCacheMappingJobService;
 import org.uniprot.api.rest.download.model.JobStatus;
 import org.uniprot.api.rest.download.queue.IllegalDownloadJobSubmissionException;
-
-import junit.framework.AssertionFailedError;
 
 @ActiveProfiles(profiles = {"producerIT"})
 @ExtendWith(SpringExtension.class)

--- a/common-rest/pom.xml
+++ b/common-rest/pom.xml
@@ -15,7 +15,6 @@
 		<hamcrest-all.version>1.3</hamcrest-all.version>
 		<poi.version>4.1.0</poi.version>
 		<jaxb.version>2.3.1</jaxb.version>
-		<testcontainers.postgres.version>1.17.3</testcontainers.postgres.version>
 		<micrometer-registry-prometheus.version>1.6.6</micrometer-registry-prometheus.version>
 		<redisson-spring-data-version>3.17.7</redisson-spring-data-version>
 	</properties>
@@ -201,8 +200,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>postgresql</artifactId>
-			<version>${testcontainers.postgres.version}</version>
+			<artifactId>testcontainers-postgresql</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/common-rest/src/test/java/org/uniprot/api/rest/validation/ValidCommaSeparatedItemsLengthTest.java
+++ b/common-rest/src/test/java/org/uniprot/api/rest/validation/ValidCommaSeparatedItemsLengthTest.java
@@ -1,7 +1,7 @@
 package org.uniprot.api.rest.validation;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/idmapping-common/pom.xml
+++ b/idmapping-common/pom.xml
@@ -118,14 +118,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<version>${testcontainers.version}</version>
+			<artifactId>testcontainers-junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>testcontainers</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>

--- a/idmapping-common/src/main/java/org/uniprot/api/idmapping/common/service/config/UniProtKBIdMappingResultsConfig.java
+++ b/idmapping-common/src/main/java/org/uniprot/api/idmapping/common/service/config/UniProtKBIdMappingResultsConfig.java
@@ -104,7 +104,9 @@ public class UniProtKBIdMappingResultsConfig {
 
     @Bean("uniproKBfacetTupleStreamTemplate")
     public FacetTupleStreamTemplate uniproKBfacetTupleStreamTemplate(
-            UniProtKBRepositoryConfigProperties configProperties, HttpClient httpClient) {
+            @Qualifier("uniProtKBRepositoryConfigProperties")
+                    UniProtKBRepositoryConfigProperties configProperties,
+            HttpClient httpClient) {
         return FacetTupleStreamTemplate.builder()
                 .collection(SolrCollection.uniprot.name())
                 .zookeeperHost(configProperties.getZkHost())

--- a/idmapping-common/src/test/java/org/uniprot/api/idmapping/common/service/job/PIRJobTaskTest.java
+++ b/idmapping-common/src/test/java/org/uniprot/api/idmapping/common/service/job/PIRJobTaskTest.java
@@ -1,8 +1,8 @@
 package org.uniprot.api.idmapping.common.service.job;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/idmapping-rest/pom.xml
+++ b/idmapping-rest/pom.xml
@@ -118,14 +118,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<version>${testcontainers.version}</version>
+			<artifactId>testcontainers-junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>testcontainers</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>

--- a/mapto-rest/pom.xml
+++ b/mapto-rest/pom.xml
@@ -14,7 +14,6 @@
 	<properties>
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
-		<testcontainers.postgres.version>1.17.3</testcontainers.postgres.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<dependencies>
@@ -71,14 +70,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>postgresql</artifactId>
-			<version>${testcontainers.postgres.version}</version>
+			<artifactId>testcontainers-postgresql</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>testcontainers</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>
@@ -89,14 +86,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<version>${testcontainers.version}</version>
+			<artifactId>testcontainers-junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>rabbitmq</artifactId>
-			<version>${testcontainers.version}</version>
+			<artifactId>testcontainers-rabbitmq</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
 		<jacoco.out.ut.file>jacoco-ut.exec</jacoco.out.ut.file>
 		<jacoco.reportPath>${jacoco.outputDir}/${jacoco.out.ut.file}</jacoco.reportPath>
 		<jacoco.version>0.8.8</jacoco.version>
-		<jackson-bom.version>2.13.4</jackson-bom.version>
-		<jackson.version>2.13.4</jackson.version>
+		<jackson-bom.version>2.15.4</jackson-bom.version>
+		<testcontainers-bom.version>2.0.5</testcontainers-bom.version>
 		<jayway.version>2.4.0</jayway.version>
 		<jna.version>5.8.0</jna.version>
 		<java.version>17</java.version>
@@ -55,7 +55,6 @@
 		<solrj.version>8.11.3</solrj.version>
 		<spring.boot.version>2.7.3</spring.boot.version>
 		<spotless.version>2.43.0</spotless.version>
-		<testcontainers.version>1.19.4</testcontainers.version>
 		<uniprot-core.version>${project.version}</uniprot-core.version>
 		<uniprot-store.version>${project.version}</uniprot-store.version>
 		<junit-jupiter.version>5.8.2</junit-jupiter.version>
@@ -86,6 +85,13 @@
 
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<groupId>org.testcontainers</groupId>
+				<artifactId>testcontainers-bom</artifactId>
+				<version>${testcontainers-bom.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
 
 			<dependency>
 				<groupId>net.jodah</groupId>
@@ -184,6 +190,12 @@
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-junit-jupiter</artifactId>
 			<version>${mockito.jupiter.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/support-data-rest/pom.xml
+++ b/support-data-rest/pom.xml
@@ -11,11 +11,6 @@
 	<artifactId>support-data-rest</artifactId>
 	<description>UniProt Rest API for support data</description>
 
-	<properties>
-		<testcontainers.postgres.version>1.17.3</testcontainers.postgres.version>
-	</properties>
-
-
 	<dependencies>
 		<dependency>
 			<groupId>io.dropwizard.metrics</groupId>
@@ -116,14 +111,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>postgresql</artifactId>
-			<version>${testcontainers.postgres.version}</version>
+			<artifactId>testcontainers-postgresql</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>testcontainers</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>
@@ -134,8 +127,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<version>${testcontainers.version}</version>
+			<artifactId>testcontainers-junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/support-data-rest/src/test/java/org/uniprot/api/support/data/configure/response/AdvancedSearchTermIT.java
+++ b/support-data-rest/src/test/java/org/uniprot/api/support/data/configure/response/AdvancedSearchTermIT.java
@@ -12,12 +12,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opentest4j.AssertionFailedError;
 import org.uniprot.store.config.UniProtDataType;
 import org.uniprot.store.search.domain.EvidenceGroup;
 import org.uniprot.store.search.domain.EvidenceItem;
 import org.uniprot.store.search.domain.impl.GoEvidences;
-
-import junit.framework.AssertionFailedError;
 
 class AdvancedSearchTermIT {
     private static final String CONTEXT_PATH = "/uniprot/api";

--- a/support-data-rest/src/test/java/org/uniprot/api/support/data/configure/response/AdvancedSearchTermTest.java
+++ b/support-data-rest/src/test/java/org/uniprot/api/support/data/configure/response/AdvancedSearchTermTest.java
@@ -6,12 +6,11 @@ import java.util.List;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
 import org.uniprot.store.config.UniProtDataType;
 import org.uniprot.store.config.searchfield.common.SearchFieldConfig;
 import org.uniprot.store.config.searchfield.factory.SearchFieldConfigFactory;
 import org.uniprot.store.config.searchfield.model.SearchFieldItem;
-
-import junit.framework.AssertionFailedError;
 
 class AdvancedSearchTermTest {
 

--- a/support-data-rest/src/test/java/org/uniprot/api/support/data/configure/service/UniParcConfigureServiceTest.java
+++ b/support-data-rest/src/test/java/org/uniprot/api/support/data/configure/service/UniParcConfigureServiceTest.java
@@ -6,11 +6,10 @@ import static org.uniprot.api.support.data.configure.service.UtilServiceTest.CON
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
 import org.uniprot.api.support.data.configure.response.AdvancedSearchTerm;
 import org.uniprot.api.support.data.configure.response.UniParcDatabaseDetail;
 import org.uniprot.api.support.data.configure.response.UniProtReturnField;
-
-import junit.framework.AssertionFailedError;
 
 /**
  * @author lgonzales

--- a/support-data-rest/src/test/java/org/uniprot/api/support/data/configure/service/UniProtKBConfigureServiceTest.java
+++ b/support-data-rest/src/test/java/org/uniprot/api/support/data/configure/service/UniProtKBConfigureServiceTest.java
@@ -8,10 +8,9 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
 import org.uniprot.api.support.data.configure.response.AdvancedSearchTerm;
 import org.uniprot.api.support.data.configure.response.UniProtReturnField;
-
-import junit.framework.AssertionFailedError;
 
 class UniProtKBConfigureServiceTest {
     private static UniProtKBConfigureService service;

--- a/support-data-rest/src/test/java/org/uniprot/api/support/data/statistics/service/StatisticsServiceTest.java
+++ b/support-data-rest/src/test/java/org/uniprot/api/support/data/statistics/service/StatisticsServiceTest.java
@@ -3,7 +3,7 @@ package org.uniprot.api.support.data.statistics.service;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 import static org.uniprot.api.support.data.statistics.TestEntityGeneratorUtil.*;

--- a/uniref-common/src/test/java/org/uniprot/api/uniref/common/repository/store/UniRefEntryStoreRepositoryTest.java
+++ b/uniref-common/src/test/java/org/uniprot/api/uniref/common/repository/store/UniRefEntryStoreRepositoryTest.java
@@ -14,6 +14,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.opentest4j.AssertionFailedError;
 import org.uniprot.api.common.exception.ResourceNotFoundException;
 import org.uniprot.api.common.repository.search.QueryResult;
 import org.uniprot.api.common.repository.search.facet.Facet;
@@ -33,8 +34,6 @@ import org.uniprot.core.uniref.impl.RepresentativeMemberBuilder;
 import org.uniprot.core.uniref.impl.UniRefEntryLightBuilder;
 import org.uniprot.store.datastore.voldemort.light.uniref.VoldemortInMemoryUniRefEntryLightStore;
 import org.uniprot.store.datastore.voldemort.member.uniref.VoldemortInMemoryUniRefMemberStore;
-
-import junit.framework.AssertionFailedError;
 
 /**
  * @author lgonzales

--- a/unisave-rest/src/test/java/org/uniprot/api/unisave/controller/UniSaveControllerTest.java
+++ b/unisave-rest/src/test/java/org/uniprot/api/unisave/controller/UniSaveControllerTest.java
@@ -1,5 +1,20 @@
 package org.uniprot.api.unisave.controller;
 
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.mockito.Mockito.*;
+import static org.springframework.http.HttpHeaders.ACCEPT;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.uniprot.api.unisave.UniSaveEntityMocker.*;
+
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,21 +41,6 @@ import org.uniprot.api.unisave.repository.domain.EntryInfo;
 import org.uniprot.api.unisave.repository.domain.EventTypeEnum;
 import org.uniprot.api.unisave.repository.domain.impl.*;
 import org.uniprot.core.uniprotkb.DeletedReason;
-
-import java.util.List;
-
-import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.mockito.Mockito.*;
-import static org.springframework.http.HttpHeaders.ACCEPT;
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.uniprot.api.unisave.UniSaveEntityMocker.*;
 
 /**
  * Created 06/04/20

--- a/unisave-rest/src/test/java/org/uniprot/api/unisave/repository/UniSaveRepositoryIT.java
+++ b/unisave-rest/src/test/java/org/uniprot/api/unisave/repository/UniSaveRepositoryIT.java
@@ -172,9 +172,7 @@ class UniSaveRepositoryIT {
 
         // then
         assertThat(entryInfo.isDeleted(), is(true));
-        assertThat(
-                entryInfo.getDeletionReason(),
-                is(DeletedReason.PROTEOME_REDUNDANCY.getName()));
+        assertThat(entryInfo.getDeletionReason(), is(DeletedReason.PROTEOME_REDUNDANCY.getName()));
     }
 
     @Test


### PR DESCRIPTION
**Summary of Changes**

- chore: TRM-34245: Introduce testcontainers bom with dependency changes to upgrade to 2.x. Note that org.apache.solr.core.SolrCore requires junit 4, hence added manually. Also as a workaround for https://github.com/testcontainers/testcontainers-java/issues/11236 jackson.version is bumped to 2.15.4
- chore: TRM-34245: Replace junit 4 usages with alternatives
- fix: TRM-34245: Fix issue with autowiring UniProtKBRepositoryConfigProperties

**Successfully run all tests and integration tests locally**

<img width="660" height="546" alt="image" src="https://github.com/user-attachments/assets/2d99c974-6c15-4a4e-96b6-375af30d7080" />

<img width="660" height="556" alt="image" src="https://github.com/user-attachments/assets/f1802271-8114-4c33-8fb7-0298c23e86ec" />
