### PR TITLE
fix: TRM-34245: Fix redisson client config loading issue due to jackson and snakeyaml mismatch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
 		<jacoco.reportPath>${jacoco.outputDir}/${jacoco.out.ut.file}</jacoco.reportPath>
 		<jacoco.version>0.8.8</jacoco.version>
 		<jackson-bom.version>2.15.4</jackson-bom.version>
+		<snakeyaml.version>1.33</snakeyaml.version>
 		<testcontainers-bom.version>2.0.5</testcontainers-bom.version>
 		<jayway.version>2.4.0</jayway.version>
 		<jna.version>5.8.0</jna.version>


### PR DESCRIPTION
`redis.yaml` is read during application startup to initiate redisson client and this was failing due to version mismatch of  jackson and snakeyaml libraries. As of now we do not have a test that uses the full application context hence, these issues are not caught. Raising this PR first to see if we encounter other issues on dev.

A separate PR will be raised to try and use full application context as a test.